### PR TITLE
Make agent take arg no-event-probes.xml on load

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/.classpath
+++ b/org.openjdk.jmc.console.ext.agent/.classpath
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/views/AgentTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/views/AgentTab.java
@@ -2,6 +2,11 @@ package org.openjdk.jmc.console.ext.agent.views;
 
 import com.sun.tools.attach.AgentInitializationException;
 import com.sun.tools.attach.VirtualMachine;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import javax.inject.Inject;
 
 import org.eclipse.swt.SWT;
@@ -17,12 +22,15 @@ import org.eclipse.ui.IMemento;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
+import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.console.ui.editor.IConsolePageContainer;
 import org.openjdk.jmc.console.ui.editor.IConsolePageStateHandler;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
 
 public class AgentTab implements IConsolePageStateHandler {
+	private static final String NO_EVENT_PROBES_XML = "no-event-probes.xml";
+	private static final String TEMP_DIR_NAME = "eventProbes";
 
 	@Inject
 	protected void createPageContent(IConsolePageContainer page, IManagedForm managedForm, IConnectionHandle handle) {
@@ -44,15 +52,6 @@ public class AgentTab implements IConsolePageStateHandler {
 		agentJarPath.setLayoutData(gridData);
 		agentJarPath.setText("Enter path...");
 
-		chartLabelContainer = toolkit.createComposite(container);
-		chartLabelContainer.setLayout(new GridLayout(2, false));
-		label = new Label(chartLabelContainer, SWT.LEFT);
-		label.setText("XML file path: ");
-		label.setLayoutData(gridData);
-		Text xmlFileText = new Text(chartLabelContainer, SWT.LEFT | SWT.BORDER);
-		xmlFileText.setLayoutData(gridData);
-		xmlFileText.setText("Enter path...");
-
 		Button button = new Button(container, SWT.PUSH);
 		button.setText("Load agent");
 		button.addListener(SWT.Selection, new Listener() {
@@ -60,17 +59,18 @@ public class AgentTab implements IConsolePageStateHandler {
 			@Override
 			public void handleEvent(Event event) {
 				String pid = handle.getServerDescriptor().getJvmInfo().getPid().toString();
-				if (loadAgent(agentJarPath.getText(),xmlFileText.getText(), pid)) {
+				if (loadAgent(agentJarPath.getText(), pid)) {
 					button.setVisible(false);
 				}
 			}
 		});
 	}
 
-	private boolean loadAgent(String agentJar, String xmlPath, String pid) {
+	private boolean loadAgent(String agentJar, String pid) {
 		try {
 			VirtualMachine vm = VirtualMachine.attach(pid);
-			vm.loadAgent(agentJar, xmlPath);
+			File tempFile = materialize(TEMP_DIR_NAME, NO_EVENT_PROBES_XML, AgentTab.class);
+			vm.loadAgent(agentJar,tempFile.getPath());
 			vm.detach();
 		} catch (AgentInitializationException e) {
 			System.err.println("ERROR: Could not access jdk.internal.misc.Unsafe! Rerun your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'.");
@@ -79,6 +79,54 @@ public class AgentTab implements IConsolePageStateHandler {
 		    throw new RuntimeException(e);
 		}
 		return true;
+	}
+
+	private static File materialize(String dir, String file, Class<?> clazz) {
+		File matDir;
+		try {
+			matDir = materialize(clazz, dir, file);
+			File matFile = new File(matDir, file);
+			return matFile;
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static File materialize(Class<?> clazz, String directoryName, String fileName) throws IOException {
+		File directory = File.createTempFile(directoryName, ".dir");
+		materialize(clazz, fileName, directory);
+		return directory;
+	}
+
+	private static void materialize(Class<?> clazz, String fileName, File directory)
+			throws IOException {
+		if (fileName == null) {
+			throw new IOException("Must specify file name to materialize");
+		}
+		if (!directory.delete()) {
+			throw new IOException("Could not delete directory: " + directory.getAbsolutePath());
+		}
+		if (!directory.mkdirs()) {
+			throw new IOException("Could not create directory: " + directory.getAbsolutePath());
+		}
+		InputStream in = null;
+		try {
+			in = clazz.getResourceAsStream(fileName);
+			if (in != null) {
+				FileOutputStream os = null;
+				try {
+					File file = new File(directory, fileName);
+					os = new FileOutputStream(file);
+					IOToolkit.copy(in, os);
+					os.close();
+				} finally {
+					IOToolkit.closeSilently(os);
+				}
+			}
+		} finally {
+			IOToolkit.closeSilently(in);
+		}
 	}
 
 	@Override

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/views/no-event-probes.xml
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/views/no-event-probes.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jfragent></jfragent>


### PR DESCRIPTION
This is a work around for #4.
When the agent is attached dynamically, a temporary XML config with no events defined is created and then its path is used as the required argument.