### PR TITLE
move the agent user-interface out of the MBeanBrowser

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/plugin.xml
+++ b/org.openjdk.jmc.console.ext.agent/plugin.xml
@@ -35,32 +35,32 @@
 <?eclipse version="3.4"?>
 <plugin>
     <extension point="org.openjdk.jmc.rjmx.actionProvider">
-   	    <action
-	    	factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
-	    	icon="icons/agent-16.png"
-	    	label="Agent Plugin">
-	    </action>
-	 	<provider
-	 		icon="icons/agent-16.png"
-	 		id="org.openjdk.jmc.console"
-	 		description="The JMC Agent Plugin can be used to add JFR instrumentation declaratively to a running program"
-	 		label="Agent Plugin"
-	 		priority="1"
-	 		doubleClickActionIndex="0">
-		    <action
-		    	factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
-		    	icon="icons/agent-16.png"
-		    	label="Open the JMC Agent Plugin">
-	    	</action>
-	 	</provider>
- 	</extension>
+        <action
+            factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
+            icon="icons/agent-16.png"
+            label="Agent Plugin">
+        </action>
+        <provider
+            icon="icons/agent-16.png"
+            id="org.openjdk.jmc.console.ext.agent.ui"
+            description="The JMC Agent Plugin can be used to add JFR instrumentation declaratively to a running program"
+            label="Agent Plugin"
+            priority="101"
+            doubleClickActionIndex="0">
+            <action
+                factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
+                icon="icons/agent-16.png"
+                label="Open the JMC Agent Plugin">
+            </action>
+        </provider>
+    </extension>
 
-	<extension point="org.eclipse.ui.editors">
-		<editor
-	 		class="org.openjdk.jmc.console.ext.agent.ui.AgentEditor"
-	 		default="true"
-	 		id="org.openjdk.jmc.console.ext.agent.ui"
-	 		icon="icons/agent-16.png"
-	 		name="Agent Plugin"/>
-	</extension>
+    <extension point="org.eclipse.ui.editors">
+        <editor
+            class="org.openjdk.jmc.console.ext.agent.ui.AgentEditor"
+            default="true"
+            id="org.openjdk.jmc.console.ext.agent.ui"
+            icon="icons/agent-16.png"
+            name="Agent Plugin"/>
+    </extension>
 </plugin>

--- a/org.openjdk.jmc.console.ext.agent/plugin.xml
+++ b/org.openjdk.jmc.console.ext.agent/plugin.xml
@@ -1,19 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--   
+   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Red Hat Inc. All rights reserved.
+   
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+   
+   The contents of this file are subject to the terms of either the Universal Permissive License 
+   v 1.0 as shown at http://oss.oracle.com/licenses/upl
+   
+   or the following license:
+   
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+   
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions
+   and the following disclaimer.
+   
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other materials provided with
+   the distribution.
+   
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior written permission.
+   
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
 <?eclipse version="3.4"?>
 <plugin>
-   
-   <extension
-         point="org.openjdk.jmc.console.ui.consolepage">
-         <consolePage
-            helpContextID="org.openjdk.jmc.console.ext.agent.views.AgentTab"
-            hostEditorId="org.openjdk.jmc.console.ui.editor"
-            placement="/#7.0"
-            icon="icons/agent-16.png"
-            id="org.openjdk.jmc.console.ext.agent.views.AgentTab"
-            name="Agent">
-            <class class="org.openjdk.jmc.console.ext.agent.views.AgentTab">
-            </class>
-      </consolePage>
-   </extension>
+    <extension point="org.openjdk.jmc.rjmx.actionProvider">
+   	    <action
+	    	factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
+	    	icon="icons/agent-16.png"
+	    	label="Agent Plugin">
+	    </action>
+	 	<provider
+	 		icon="icons/agent-16.png"
+	 		id="org.openjdk.jmc.console"
+	 		description="The JMC Agent Plugin can be used to add JFR instrumentation declaratively to a running program"
+	 		label="Agent Plugin"
+	 		priority="1"
+	 		doubleClickActionIndex="0">
+		    <action
+		    	factory="org.openjdk.jmc.console.ext.agent.ui.AgentEditorOpener"
+		    	icon="icons/agent-16.png"
+		    	label="Open the JMC Agent Plugin">
+	    	</action>
+	 	</provider>
+ 	</extension>
 
+	<extension point="org.eclipse.ui.editors">
+		<editor
+	 		class="org.openjdk.jmc.console.ext.agent.ui.AgentEditor"
+	 		default="true"
+	 		id="org.openjdk.jmc.console.ext.agent.ui"
+	 		icon="icons/agent-16.png"
+	 		name="Agent Plugin"/>
+	</extension>
 </plugin>

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentEditor.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.ui;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorSite;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.forms.widgets.Form;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.openjdk.jmc.console.ui.editor.internal.ConsoleEditor;
+import org.openjdk.jmc.ui.UIPlugin;
+
+@SuppressWarnings("restriction")
+public class AgentEditor extends ConsoleEditor {
+
+	private FormToolkit formToolkit;
+	private Composite parent;
+	private AgentUi agentUi;
+
+	@Override
+	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
+		super.init(site, input);
+		setPartName("JMC Agent Plugin: " + getEditorInput().getName());
+	}
+
+	@Override
+	public void createPartControl(Composite parent) {
+		this.parent = parent;
+		formToolkit = new FormToolkit(UIPlugin.getDefault().getFormColors(Display.getCurrent()));
+		formToolkit.setBorderStyle(SWT.NULL);
+		createAgentUi(parent);
+	}
+
+	public void createAgentUi(Composite parent) {
+		Form form = formToolkit.createForm(parent);
+		form.setText("Agent");
+		form.setImage(getTitleImage());
+		formToolkit.decorateFormHeading(form);
+		Composite body = form.getBody();
+		body.setLayout(new FillLayout());
+		agentUi = new AgentUi(body, SWT.NONE, getEditorInput().getServerHandle());
+	}
+	
+	@Override
+	public void doSave(IProgressMonitor monitor) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void doSaveAs() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public boolean isDirty() {
+		return false;
+	}
+
+	@Override
+	public boolean isSaveAsAllowed() {
+		return false;
+	}
+
+	@Override
+	public void setFocus() {
+		if (agentUi != null) {
+			agentUi.setFocus();
+			return;
+		}
+		parent.setFocus();
+	}
+
+	@Override
+	protected void addPages() {
+		// TODO Auto-generated method stub
+	}
+
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentEditorOpener.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentEditorOpener.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.ui;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.openjdk.jmc.console.ui.editor.internal.ConsoleEditorInput;
+import org.openjdk.jmc.rjmx.IServerHandle;
+import org.openjdk.jmc.rjmx.actionprovider.IActionFactory;
+import org.openjdk.jmc.ui.common.action.Executable;
+import org.openjdk.jmc.ui.misc.DialogToolkit;
+import org.openjdk.jmc.ui.misc.DisplayToolkit;
+
+@SuppressWarnings("restriction")
+public class AgentEditorOpener implements IActionFactory {
+
+	@Override
+	public Executable createAction(IServerHandle serverHandle) {
+		return new Executable() {
+
+			@Override
+			public void execute() throws Exception {
+				DisplayToolkit.safeAsyncExec(Display.getDefault(), new Runnable () {
+					@Override
+					public void run() {
+						IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+						try {
+							IEditorInput ei = new ConsoleEditorInput(serverHandle);
+							window.getActivePage().openEditor(ei, AgentPlugin.PLUGIN_ID, true);
+						} catch (Exception e) {
+							DialogToolkit.showException(window.getShell(),
+									"Failed to open the JMC Agent Plugin.", e);
+						}
+					}
+				});
+			}
+		};
+	}
+
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentPlugin.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentPlugin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.ui;
+
+import org.openjdk.jmc.ui.MCAbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+public class AgentPlugin extends MCAbstractUIPlugin {
+	protected static final String PLUGIN_ID = "org.openjdk.jmc.console.ext.agent.ui"; //$NON-NLS-1$
+
+	private static AgentPlugin m_plugin;
+
+	public AgentPlugin() {
+		super(PLUGIN_ID);
+	}
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		m_plugin = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		m_plugin = null;
+		super.stop(context);
+	}
+
+	public static AgentPlugin getDefault() {
+		return m_plugin;
+	}
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
@@ -1,13 +1,42 @@
-package org.openjdk.jmc.console.ext.agent.views;
-
-import com.sun.tools.attach.AgentInitializationException;
-import com.sun.tools.attach.VirtualMachine;
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.ui;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.inject.Inject;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -20,31 +49,22 @@ import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.ui.IMemento;
-import org.eclipse.ui.forms.IManagedForm;
-import org.eclipse.ui.forms.widgets.FormToolkit;
-import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.openjdk.jmc.common.io.IOToolkit;
-import org.openjdk.jmc.console.ui.editor.IConsolePageContainer;
-import org.openjdk.jmc.console.ui.editor.IConsolePageStateHandler;
-import org.openjdk.jmc.rjmx.IConnectionHandle;
-import org.openjdk.jmc.ui.misc.MCLayoutFactory;
+import org.openjdk.jmc.rjmx.IServerHandle;
 
-public class AgentTab implements IConsolePageStateHandler {
-	private static final String NO_EVENT_PROBES_XML = "no-event-probes.xml";
-	private static final String TEMP_DIR_NAME = "eventProbes";
-	private static final String ENTER_PATH_MSG = "Enter Path...";
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.VirtualMachine;
 
-	@Inject
-	protected void createPageContent(IConsolePageContainer page, IManagedForm managedForm, IConnectionHandle handle) {
-		// Create SectionPartManager
-		ScrolledForm form = managedForm.getForm();
-		FormToolkit toolkit = managedForm.getToolkit();
+public class AgentUi extends Composite {
 
-		Composite container = form.getBody();
-		container.setLayout(MCLayoutFactory.createFormPageLayout());
+    private static final String NO_EVENT_PROBES_XML = "no-event-probes.xml";
+    private static final String TEMP_DIR_NAME = "eventProbes";
+    private static final String ENTER_PATH_MSG = "Enter Path...";
 
-		Composite chartLabelContainer = toolkit.createComposite(container);
+	public AgentUi(Composite parent, int style, IServerHandle handle) {
+		super(parent, style);
+		this.setLayout(new GridLayout());
+		Composite chartLabelContainer = new Composite(this, SWT.NO_BACKGROUND);
 		chartLabelContainer.setLayout(new GridLayout(3, false));
 
 		Label label = new Label(chartLabelContainer, SWT.NULL);
@@ -88,7 +108,7 @@ public class AgentTab implements IConsolePageStateHandler {
 			}
 		});
 
-		Button button = new Button(container, SWT.PUSH);
+		Button button = new Button(this, SWT.PUSH);
 		button.setText("Load agent");
 		button.addListener(SWT.Selection, new Listener() {
 
@@ -106,7 +126,7 @@ public class AgentTab implements IConsolePageStateHandler {
 		try {
 			VirtualMachine vm = VirtualMachine.attach(pid);
 			if (xmlPath == null || xmlPath == ENTER_PATH_MSG) {
-				File tempFile = materialize(TEMP_DIR_NAME, NO_EVENT_PROBES_XML, AgentTab.class);
+				File tempFile = materialize(TEMP_DIR_NAME, NO_EVENT_PROBES_XML, AgentUi.class);
 				xmlPath = tempFile.getPath();
 			}
 			vm.loadAgent(agentJar, xmlPath);
@@ -166,18 +186,6 @@ public class AgentTab implements IConsolePageStateHandler {
 		} finally {
 			IOToolkit.closeSilently(in);
 		}
-	}
-
-	@Override
-	public boolean saveState(IMemento state) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public void dispose() {
-		// TODO Auto-generated method stub
-
 	}
 
 }


### PR DESCRIPTION
This PR aims to address https://github.com/rh-jmc-team/jmc-agent-plugin/issues/10, in which it'd be nice to move the Agent plugin to be outside of the MBeanBrowser.

I modelled these changes after the existing consoles pages and the JOverflow plugin, so I hope the format is okay.

Let me know what you think.