### PR TITLE
Display current transformed events

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
@@ -51,6 +51,7 @@ import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.openjdk.jmc.rjmx.IServerHandle;
 
 import com.sun.tools.attach.AgentInitializationException;
@@ -63,8 +64,9 @@ public class AgentUi extends Composite {
     private static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
     private VirtualMachine vm;
     private MBeanServerConnection mbsc;
+    private EventTreeSection eventTree;
 
-	public AgentUi(Composite parent, int style, IServerHandle handle) {
+	public AgentUi(Composite parent, int style, IServerHandle handle, FormToolkit toolkit) {
 		super(parent, style);
 		this.setLayout(new GridLayout());
 		Composite chartLabelContainer = new Composite(this, SWT.NO_BACKGROUND);
@@ -121,10 +123,14 @@ public class AgentUi extends Composite {
 				vm = initVM(pid);
 				if (loadAgent(agentJarPath.getText(), xmlPath.getText())) {
 					mbsc = initMBeanServerConnection();
+					eventTree.setMBeanServerConnection(mbsc);
+					eventTree.setVisible(true);
 					button.setVisible(false);
 				}
 			}
 		});
+		eventTree = new EventTreeSection(this, toolkit);
+		eventTree.setVisible(false);
 	}
 
 	private boolean loadAgent(String agentJar, String xmlPath) {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeLabelProvider.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeLabelProvider.java
@@ -33,82 +33,48 @@
  */
 package org.openjdk.jmc.console.ext.agent.ui;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorSite;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.forms.widgets.Form;
-import org.eclipse.ui.forms.widgets.FormToolkit;
-import org.openjdk.jmc.console.ui.editor.internal.ConsoleEditor;
-import org.openjdk.jmc.ui.UIPlugin;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.Image;
 
-@SuppressWarnings("restriction")
-public class AgentEditor extends ConsoleEditor {
+import org.openjdk.jmc.ui.common.tree.ITreeNode;
 
-	private FormToolkit formToolkit;
-	private Composite parent;
-	private AgentUi agentUi;
+public class EventTreeLabelProvider extends ColumnLabelProvider {
 
 	@Override
-	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
-		super.init(site, input);
-		setPartName("JMC Agent Plugin: " + getEditorInput().getName());
+	public Image getImage(Object element) {
+		return null;
 	}
 
 	@Override
-	public void createPartControl(Composite parent) {
-		this.parent = parent;
-		formToolkit = new FormToolkit(UIPlugin.getDefault().getFormColors(Display.getCurrent()));
-		formToolkit.setBorderStyle(SWT.NULL);
-		createAgentUi(parent);
-	}
-
-	public void createAgentUi(Composite parent) {
-		Form form = formToolkit.createForm(parent);
-		form.setText("Agent");
-		form.setImage(getTitleImage());
-		formToolkit.decorateFormHeading(form);
-		Composite body = form.getBody();
-		body.setLayout(new FillLayout());
-		agentUi = new AgentUi(body, SWT.NONE, getEditorInput().getServerHandle(), formToolkit);
-	}
-	
-	@Override
-	public void doSave(IProgressMonitor monitor) {
-		// TODO Auto-generated method stub
-	}
-
-	@Override
-	public void doSaveAs() {
-		// TODO Auto-generated method stub
-	}
-
-	@Override
-	public boolean isDirty() {
-		return false;
-	}
-
-	@Override
-	public boolean isSaveAsAllowed() {
-		return false;
-	}
-
-	@Override
-	public void setFocus() {
-		if (agentUi != null) {
-			agentUi.setFocus();
-			return;
+	public String getText(Object element) {
+		Object data = ((ITreeNode) element).getUserData();
+		if (data instanceof String) {
+			return (String) data;
+		} else {
+			throw new IllegalArgumentException(
+					"This label provider only supports String types: " + data); //$NON-NLS-1$
 		}
-		parent.setFocus();
 	}
 
 	@Override
-	protected void addPages() {
-		// TODO Auto-generated method stub
+	public Font getFont(Object element) {
+		return super.getFont(element);
+	}
+
+	@Override
+	public Color getForeground(Object element) {
+		return super.getForeground(element);
+	}
+
+	@Override
+	public String getToolTipText(Object element) {
+		Object data = ((ITreeNode) element).getUserData();
+		if (data instanceof String) {
+			return (String) data;
+		}
+		return null;
 	}
 
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeSection.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.console.ext.agent.ui;
 
 import java.io.IOException;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/EventTreeSection.java
@@ -1,0 +1,157 @@
+package org.openjdk.jmc.console.ext.agent.ui;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.openjdk.jmc.rjmx.ui.internal.TreeNodeBuilder;
+import org.openjdk.jmc.ui.common.tree.ITreeNode;
+import org.openjdk.jmc.ui.misc.MCLayoutFactory;
+import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
+
+
+public class EventTreeSection extends Composite {
+	private static final String EVENTS_TREE_NAME = "AgentUi.EventsTree";
+	private static final String NO_TRANSFORMED_EVENTS_MSG = "No events are currently transformed";
+	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController";
+	private static final String SECTION_LABEL = "Current Transfromed Events";
+	private static final String GET_EVENTS = "Get Events";
+	private static final List<String> COMPOSITE_DATA_TYPES = new ArrayList<>(Arrays.asList("returnValue", "method"));
+	private static final List<String> COMPOSITE_DATA_ARRAY_TYPES = new ArrayList<>(Arrays.asList("fields", "parameters"));
+	private final TreeViewer viewer;
+	private MBeanServerConnection mbsc;
+
+	public EventTreeSection(Composite parent, FormToolkit toolkit) {
+		super(parent, SWT.NONE);
+		this.setLayout(new GridLayout());
+		this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		Composite eventsControlContainer = new Composite(this, SWT.NO_BACKGROUND);
+		eventsControlContainer.setLayout(new GridLayout(2, false));
+		GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, false);
+		eventsControlContainer.setLayoutData(gridData);
+
+		Label label = new Label(eventsControlContainer, SWT.NULL);
+		label.setText(SECTION_LABEL);
+		Button eventsButton = new Button(eventsControlContainer, SWT.PUSH);
+		eventsButton.setText(GET_EVENTS);
+		eventsButton.addListener(SWT.Selection, new Listener() {
+			@Override
+			public void handleEvent(Event event) {
+				final ITreeNode[] nodes = buildTreeModel(doRetrieveCurrentTransforms());
+				viewer.getControl().setRedraw(false);
+				viewer.setInput(nodes);
+				viewer.getControl().setRedraw(true);
+				viewer.getControl().redraw();
+			}
+		});
+
+		viewer = createViewer(this, toolkit);
+		viewer.getControl()
+				.setLayoutData(MCLayoutFactory.createFormPageLayoutData(SWT.DEFAULT, SWT.DEFAULT, true, true));
+	}
+
+	public void setMBeanServerConnection(MBeanServerConnection mbsc) {
+		this.mbsc = mbsc;
+	}
+
+	private CompositeData[] doRetrieveCurrentTransforms() {
+		if (mbsc == null) {
+			System.err.println("ERROR: no MBeanServerConnection exists, cannot invoke retrieveCurrentTransforms");
+			return null;
+		}
+		try {
+			Object result = mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), "retrieveCurrentTransforms", new Object[0], new String[0]);
+			return (CompositeData[]) result;
+		} catch (InstanceNotFoundException | MalformedObjectNameException | MBeanException | ReflectionException
+				| IOException e) {
+			System.err.println("ERROR: Could not retrieve current transforms");
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private TreeViewer createViewer(Composite parent, FormToolkit formToolkit) {
+		Tree tree = formToolkit.createTree(parent, SWT.NONE);
+		tree.setData("name", EVENTS_TREE_NAME); //$NON-NLS-1$
+		tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		TreeViewer viewer = new TreeViewer(tree);
+		viewer.setUseHashlookup(true);
+		viewer.setContentProvider(new TreeStructureContentProvider());
+		viewer.setLabelProvider(new EventTreeLabelProvider());
+
+		return viewer;
+	}
+
+	private ITreeNode[] buildTreeModel(CompositeData[] cds) {
+		TreeNodeBuilder root = new TreeNodeBuilder();
+		if (cds == null || cds.length == 0) {
+			root.getUniqueChild(NO_TRANSFORMED_EVENTS_MSG);
+		} else {
+			for (CompositeData cd : cds) {
+				TreeNodeBuilder node = root.getUniqueChild(cd.get("eventName").toString());
+				buildChildNodes(cd, node);
+			}
+		}
+		return root.getChildren(null);
+	}
+
+	private void buildChildNodes(CompositeData cd, TreeNodeBuilder rootNode) {
+		Set<String> keys = cd.getCompositeType().keySet();
+		for (String key : keys) {
+			if (!isEmptyCompositeData(cd, key)) {
+				TreeNodeBuilder parent = rootNode.get(key);
+				parent.setValue(key);
+				if (COMPOSITE_DATA_TYPES.contains(key)) {
+					buildChildNodes((CompositeData) cd.get(key), parent);
+				} else if (COMPOSITE_DATA_ARRAY_TYPES.contains(key)) {
+					CompositeData[] childCds = (CompositeData[]) cd.get(key);
+					for (int i = 0; i < childCds.length; i++) {
+						String childKey = key + " " + i;
+						TreeNodeBuilder childNode = parent.get(childKey);
+						childNode.setValue(childKey);
+						buildChildNodes(childCds[i], childNode);
+					}
+				} else {
+					String value = cd.get(key).toString();
+					TreeNodeBuilder child = parent.get(value);
+					child.setValue(value);
+				}
+			}
+		}
+	}
+
+	private boolean isEmptyCompositeData(CompositeData cd, String key) {
+		if (cd.get(key) == null) {
+			return true;
+		}
+		try {
+			CompositeData[] cds = (CompositeData[]) cd.get(key);
+			return cds.length == 0;
+		} catch (ClassCastException e) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
This patch adds a visual of the current transformed events that have been applied to the user's running application.
After the user has attached the agent to their application the "Get Events" button appears.

![Screenshot from 2020-04-02 11-36-55](https://user-images.githubusercontent.com/29706926/78271495-35a63900-74da-11ea-919c-016204d142b5.png)

Closes #7 
Let me know what you think!