### PR TITLE
Make AgentJMXFacade helper class

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.ui;
+
+import java.io.IOException;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+
+public class AgentJMXHelper {
+	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController";
+	private static final String DEFINE_EVENT_PROBES = "defineEventProbes";
+	private static final String RETRIEVE_CURRENT_TRANSFORMS = "retrieveCurrentTransforms";
+
+	private MBeanServerConnection mbsc;
+
+	AgentJMXHelper(MBeanServerConnection mbsc) {
+		this.mbsc = mbsc;
+	}
+
+	public CompositeData[] retrieveCurrentTransforms() {
+		if (mbsc == null) {
+			System.err.println("ERROR: no MBeanServerConnection exists, cannot invoke retrieveCurrentTransforms");
+			return null;
+		}
+		try {
+			Object result = mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), RETRIEVE_CURRENT_TRANSFORMS, new Object[0], new String[0]);
+			return (CompositeData[]) result;
+		} catch (InstanceNotFoundException | MalformedObjectNameException | MBeanException | ReflectionException
+				| IOException e) {
+			System.err.println("ERROR: Could not retrieve current transforms");
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public void defineEventProbes(String xmlDescription) {
+		if (mbsc == null) {
+			System.err.println("ERROR: no MBeanServerConnection exists, cannot invoke defineEventProbes");
+			return;
+		}
+		try {
+			Object[] params = {xmlDescription};
+			String[] signature = {String.class.getName()};
+			mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), DEFINE_EVENT_PROBES, params, signature);
+		} catch (InstanceNotFoundException | MalformedObjectNameException | MBeanException | ReflectionException
+				| IOException e) {
+			System.err.println("ERROR: Could not define event probes: " + xmlDescription);
+			e.printStackTrace();
+		}
+	}
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
@@ -34,6 +34,7 @@
 package org.openjdk.jmc.console.ext.agent.ui;
 
 import java.io.IOException;
+import java.util.logging.Level;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
@@ -51,38 +52,32 @@ public class AgentJMXHelper {
 	private MBeanServerConnection mbsc;
 
 	AgentJMXHelper(MBeanServerConnection mbsc) {
+		if (mbsc == null) {
+			AgentUi.getLogger().log(Level.SEVERE, "The MBeanServerConnection cannot be null");
+			return;
+		}
 		this.mbsc = mbsc;
 	}
 
 	public CompositeData[] retrieveCurrentTransforms() {
-		if (mbsc == null) {
-			System.err.println("ERROR: no MBeanServerConnection exists, cannot invoke retrieveCurrentTransforms");
-			return null;
-		}
 		try {
 			Object result = mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), RETRIEVE_CURRENT_TRANSFORMS, new Object[0], new String[0]);
 			return (CompositeData[]) result;
 		} catch (InstanceNotFoundException | MalformedObjectNameException | MBeanException | ReflectionException
 				| IOException e) {
-			System.err.println("ERROR: Could not retrieve current transforms");
-			e.printStackTrace();
+			AgentUi.getLogger().log(Level.WARNING, "Could not retrieve current transforms", e);
 		}
 		return null;
 	}
 
 	public void defineEventProbes(String xmlDescription) {
-		if (mbsc == null) {
-			System.err.println("ERROR: no MBeanServerConnection exists, cannot invoke defineEventProbes");
-			return;
-		}
 		try {
 			Object[] params = {xmlDescription};
 			String[] signature = {String.class.getName()};
 			mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), DEFINE_EVENT_PROBES, params, signature);
 		} catch (InstanceNotFoundException | MalformedObjectNameException | MBeanException | ReflectionException
 				| IOException e) {
-			System.err.println("ERROR: Could not define event probes: " + xmlDescription);
-			e.printStackTrace();
+			AgentUi.getLogger().log(Level.WARNING, "Could not define event probes: " + xmlDescription, e);
 		}
 	}
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
@@ -34,6 +34,8 @@
 package org.openjdk.jmc.console.ext.agent.ui;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
@@ -134,6 +136,10 @@ public class AgentUi extends Composite {
 		eventTree.setVisible(false);
 	}
 
+	public static Logger getLogger() {
+		return Logger.getLogger(AgentUi.class.getName());
+	}
+
 	private boolean loadAgent(String agentJar, String xmlPath) {
 		try {
 			if (xmlPath == null || xmlPath.equals(ENTER_PATH_MSG)) {
@@ -142,7 +148,8 @@ public class AgentUi extends Composite {
 				vm.loadAgent(agentJar, xmlPath);
 			}
 		} catch (AgentInitializationException e) {
-			System.err.println("ERROR: Could not access jdk.internal.misc.Unsafe! Rerun your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'.");
+			getLogger().log(Level.SEVERE,
+					"Could not access jdk.internal.misc.Unsafe! Rerun your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'.", e);
 			return false;
 		} catch (Exception e) {
 		    throw new RuntimeException(e);
@@ -155,8 +162,7 @@ public class AgentUi extends Composite {
 		try {
 			vm = VirtualMachine.attach(pid);
 		} catch (AttachNotSupportedException | IOException e) {
-			System.err.println("ERROR: Could not attatch process with pid " + pid + " and create a VirtualMachine");
-			e.printStackTrace();
+			getLogger().log(Level.SEVERE, "Could not attatch process with pid " + pid + " and create a VirtualMachine", e);
 		}
 		return vm;
 	}
@@ -174,7 +180,7 @@ public class AgentUi extends Composite {
 
 			mbsc = jmxConnector.getMBeanServerConnection();
 		} catch (Exception e) {
-			e.printStackTrace();
+			getLogger().log(Level.SEVERE, "Could not create a MBeanServerConnection", e);
 		}
 		return mbsc;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
@@ -63,7 +63,7 @@ public class AgentUi extends Composite {
     private static final String ENTER_PATH_MSG = "Enter Path...";
     private static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
     private VirtualMachine vm;
-    private MBeanServerConnection mbsc;
+    private AgentJMXHelper agentJMXHelper;
     private EventTreeSection eventTree;
 
 	public AgentUi(Composite parent, int style, IServerHandle handle, FormToolkit toolkit) {
@@ -122,8 +122,9 @@ public class AgentUi extends Composite {
 				String pid = handle.getServerDescriptor().getJvmInfo().getPid().toString();
 				vm = initVM(pid);
 				if (loadAgent(agentJarPath.getText(), xmlPath.getText())) {
-					mbsc = initMBeanServerConnection();
-					eventTree.setMBeanServerConnection(mbsc);
+					MBeanServerConnection mbsc = initMBeanServerConnection();
+					agentJMXHelper = new AgentJMXHelper(mbsc);
+					eventTree.setAgentJMXHelper(agentJMXHelper);
 					eventTree.setVisible(true);
 					button.setVisible(false);
 				}


### PR DESCRIPTION
This patch makes a jmx helper class.

I am not sure if there is a better way to call the retrieveCurrentTransforms jmx operation from the EventTreeSection class - or if it should be called somewhere else?  Right now I am setting a private agentJXMHelper variable in the EventtreeSection class with the setAgentJXMHelper function.  

Closes #19 