### PR TITLE
Check if agent is loaded by checking if MXBean is registered

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
@@ -59,6 +59,16 @@ public class AgentJMXHelper {
 		this.mbsc = mbsc;
 	}
 
+	public boolean isMXBeanRegistered() {
+		try {
+			return mbsc.isRegistered(new ObjectName(AGENT_OBJECT_NAME));
+		} catch (MalformedObjectNameException | IOException e) {
+			AgentUi.getLogger().log(Level.SEVERE, "Could not check if agent MXBean is registered", e);
+
+		}
+		return false;
+	}
+
 	public CompositeData[] retrieveCurrentTransforms() {
 		try {
 			Object result = mbsc.invoke(new ObjectName(AGENT_OBJECT_NAME), RETRIEVE_CURRENT_TRANSFORMS, new Object[0], new String[0]);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentJMXHelper.java
@@ -64,7 +64,6 @@ public class AgentJMXHelper {
 			return mbsc.isRegistered(new ObjectName(AGENT_OBJECT_NAME));
 		} catch (MalformedObjectNameException | IOException e) {
 			AgentUi.getLogger().log(Level.SEVERE, "Could not check if agent MXBean is registered", e);
-
 		}
 		return false;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/ui/AgentUi.java
@@ -70,7 +70,9 @@ public class AgentUi extends Composite {
 
 		String pid = handle.getServerDescriptor().getJvmInfo().getPid().toString();
 		vm = initVM(pid);
-		if (isAgentLoaded()) {
+		MBeanServerConnection mbsc = initMBeanServerConnection();
+		agentJMXHelper = new AgentJMXHelper(mbsc);
+		if (agentJMXHelper.isMXBeanRegistered()) {
 			setUpJMXRelatedComponents();
 		} else {
 			loadAgentSection = new LoadAgentSection(this, vm);
@@ -92,30 +94,7 @@ public class AgentUi extends Composite {
 		return vm;
 	}
 
-	private boolean isAgentLoaded() {
-		String connectorAddress = null;
-		try {
-			connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
-		} catch (IOException e) {
-			getLogger().log(Level.SEVERE, "Could not check if agent has been loaded dynamically", e);
-			return false;
-		}
-		if (connectorAddress == null) {
-			String vmArgs = null;
-			try {
-				vmArgs = vm.getAgentProperties().getProperty(CONNECTOR_ARGS);
-			} catch (IOException e) {
-				getLogger().log(Level.SEVERE, "Could not check if agent has been loaded statically", e);
-				return false;
-			}
-			return vmArgs.contains("-javaagent:");
-		}
-		return true;
-	}
-
 	private void setUpJMXRelatedComponents() {
-		MBeanServerConnection mbsc = initMBeanServerConnection();
-		agentJMXHelper = new AgentJMXHelper(mbsc);
 		eventTree = new EventTreeSection(this, toolkit);
 		eventTree.setAgentJMXHelper(agentJMXHelper);
 	}


### PR DESCRIPTION
This closes #24.

It changes the way the check to see if the agent has been loaded is performed.  Now this is done by checking if "org.openjdk.jmc.jfr.agent:type=AgentController" if registered with the MBean Server Connection.