### PR TITLE
Support attaching to an already running agent on a remote JVM

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
@@ -33,7 +33,10 @@
  */
 package org.openjdk.jmc.console.ext.agent;
 
+import org.openjdk.jmc.rjmx.IConnectionHandle;
+
 import java.io.IOException;
+import java.util.Objects;
 import java.util.logging.Level;
 
 import javax.management.InstanceNotFoundException;
@@ -44,19 +47,29 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 
-public class AgentJMXHelper {
+public class AgentJmxHelper {
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController";
 	private static final String DEFINE_EVENT_PROBES = "defineEventProbes";
 	private static final String RETRIEVE_CURRENT_TRANSFORMS = "retrieveCurrentTransforms";
 
-	private MBeanServerConnection mbsc;
+	final private IConnectionHandle connectionHandle;
+	final private MBeanServerConnection mbsc;
 
-	public AgentJMXHelper(MBeanServerConnection mbsc) {
-		if (mbsc == null) {
-			AgentPlugin.getDefault().getLogger().log(Level.SEVERE, "The MBeanServerConnection cannot be null");
-			return;
-		}
-		this.mbsc = mbsc;
+	public AgentJmxHelper(IConnectionHandle connectionHandle) {
+		this.connectionHandle = Objects.requireNonNull(connectionHandle);
+		mbsc = connectionHandle.getServiceOrDummy(MBeanServerConnection.class);
+	}
+
+	public IConnectionHandle getConnectionHandle() {
+		return connectionHandle;
+	}
+
+	public MBeanServerConnection getMBeanServerConnection() {
+		return mbsc;
+	}
+
+	public boolean isLocalJvm() {
+		return connectionHandle.getServerDescriptor().getJvmInfo() != null;
 	}
 
 	public boolean isMXBeanRegistered() {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
@@ -51,7 +51,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.ui.forms.widgets.FormToolkit;
-import org.openjdk.jmc.console.ext.agent.AgentJMXHelper;
+import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.rjmx.ui.internal.TreeNodeBuilder;
 import org.openjdk.jmc.ui.common.tree.ITreeNode;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
@@ -67,7 +67,7 @@ public class EventTreeSection extends Composite {
 			Arrays.asList("fields", "parameters"));
 
 	private final TreeViewer viewer;
-	private AgentJMXHelper agentJMXHelper;
+	private AgentJmxHelper agentJMXHelper;
 
 	public EventTreeSection(Composite parent, FormToolkit toolkit) {
 		super(parent, SWT.NONE);
@@ -100,7 +100,7 @@ public class EventTreeSection extends Composite {
 				.setLayoutData(MCLayoutFactory.createFormPageLayoutData(SWT.DEFAULT, SWT.DEFAULT, true, true));
 	}
 
-	public void setAgentJMXHelper(AgentJMXHelper agentJMXHelper) {
+	public void setAgentJMXHelper(AgentJmxHelper agentJMXHelper) {
 		this.agentJMXHelper = agentJMXHelper;
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/LiveConfigTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/LiveConfigTab.java
@@ -7,7 +7,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
-import org.openjdk.jmc.console.ext.agent.AgentJMXHelper;
+import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
@@ -24,7 +24,7 @@ public class LiveConfigTab extends AgentFormPage {
 	}
 
 	@Inject
-	protected void createPageContent(IManagedForm managedForm, IConnectionHandle handle) {
+	protected void createPageContent(IManagedForm managedForm, AgentJmxHelper helper, IConnectionHandle handle) {
 		ScrolledForm form = managedForm.getForm();
 		FormToolkit toolkit = managedForm.getToolkit();
 
@@ -33,8 +33,7 @@ public class LiveConfigTab extends AgentFormPage {
 
 		MBeanServerConnection mbeanServer = handle.getServiceOrDummy(MBeanServerConnection.class);
 		eventTree = new EventTreeSection(container, toolkit);
-		AgentJMXHelper agentJMXHelper = new AgentJMXHelper(mbeanServer);
-		eventTree.setAgentJMXHelper(agentJMXHelper);
+		eventTree.setAgentJMXHelper(helper);
 	}
 
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
@@ -22,7 +22,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.openjdk.jmc.console.ext.agent.AgentJMXHelper;
+import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlEditor;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ProbeValidator;
@@ -39,7 +39,7 @@ public class EditAgentSection extends Composite {
 	private static final String MESSAGE_APPLY = "Apply";
 	private static final String MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND = "No errors/warnings found!";
 
-	private AgentJMXHelper agentJMXHelper = null;
+	private AgentJmxHelper agentJMXHelper = null;
 
 	final private Label messageOutput;
 
@@ -125,7 +125,7 @@ public class EditAgentSection extends Composite {
 		parent.layout(true, true);
 	}
 
-	public void setAgentJMXHelper(AgentJMXHelper agentJMXHelper) {
+	public void setAgentJMXHelper(AgentJmxHelper agentJMXHelper) {
 		this.agentJMXHelper = agentJMXHelper;
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/PresetsTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/PresetsTab.java
@@ -6,7 +6,7 @@ import javax.management.MBeanServerConnection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
-import org.openjdk.jmc.console.ext.agent.AgentJMXHelper;
+import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
@@ -24,16 +24,13 @@ public class PresetsTab extends AgentFormPage {
 	}
 
 	@Inject
-	protected void createPageContent(IManagedForm managedForm, IConnectionHandle handle) {
+	protected void createPageContent(IManagedForm managedForm, AgentJmxHelper helper, IConnectionHandle handle) {
 		ScrolledForm form = managedForm.getForm();
 		Composite container = form.getBody();
 		container.setLayout(MCLayoutFactory.createFormPageLayout());
 
-		MBeanServerConnection mbeanServer = handle.getServiceOrDummy(MBeanServerConnection.class);
-		AgentJMXHelper agentJMXHelper = new AgentJMXHelper(mbeanServer);
-
 		editAgentSection = new EditAgentSection(container);
-		editAgentSection.setAgentJMXHelper(agentJMXHelper);
+		editAgentSection.setAgentJMXHelper(helper);
 	}
 
 }


### PR DESCRIPTION
If an agent is already running on a remote JVM and the mbean controller is exposed, the agent plugin will connect with rjmx. Otherwise, an error message appears explaining starting agent directly on remote jvm is not supported.

Closes #34.