### PR TITLE
Make table able to display no events

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
@@ -125,7 +125,10 @@ public class EventTreeSection extends MCSectionPart {
 				if (selected != null) {
 					String eventName = ((DefaultTreeNode) selected).getUserData().toString();
 					infoPart.showEvent(eventName);
+				} else {
+					infoPart.showEvent(null);
 				}
+
 			}
 		});
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
@@ -128,7 +128,6 @@ public class EventTreeSection extends MCSectionPart {
 				} else {
 					infoPart.showEvent(null);
 				}
-
 			}
 		});
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/FeatureTableSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/FeatureTableSection.java
@@ -112,11 +112,13 @@ public class FeatureTableSection extends MCSectionPart {
 
 	private List<Object> createEventProperties(CompositeData cd) throws Exception {
 		List<Object> attributes = new ArrayList<>();
-		Set<String> keys = cd.getCompositeType().keySet();
-		for (String key : keys) {
-			if (!isEmptyCompositeData(cd, key) && !EventAttributes.ATTRIBUTE_LIST.contains(key)) {
-				attributes.add(
-						new EventReadOnlyAttribute(key, cd.getCompositeType().getType(key).getClassName(), cd.get(key)));
+		if (cd != null) {
+			Set<String> keys = cd.getCompositeType().keySet();
+			for (String key : keys) {
+				if (!isEmptyCompositeData(cd, key) && !EventAttributes.ATTRIBUTE_LIST.contains(key)) {
+					attributes.add(
+							new EventReadOnlyAttribute(key, cd.getCompositeType().getType(key).getClassName(), cd.get(key)));
+				}
 			}
 		}
 		return attributes;
@@ -124,10 +126,12 @@ public class FeatureTableSection extends MCSectionPart {
 
 	private List<Object> createEventAttributes(CompositeData cd) throws Exception {
 		List<Object> attributes = new ArrayList<>();
-		for (String key : EventAttributes.ATTRIBUTE_LIST) {
-			if (!isEmptyCompositeData(cd, key)) {
-				attributes.add(
-						new EventReadOnlyAttribute(key, cd.getCompositeType().getType(key).getClassName(), cd.get(key)));
+		if (cd != null) {
+			for (String key : EventAttributes.ATTRIBUTE_LIST) {
+				if (!isEmptyCompositeData(cd, key)) {
+					attributes.add(
+							new EventReadOnlyAttribute(key, cd.getCompositeType().getType(key).getClassName(), cd.get(key)));
+				}
 			}
 		}
 		return attributes;


### PR DESCRIPTION
When all transformed events are reverted, previously, the information that was last selected in the Events Table did not disappear on refresh.  This patch fixes this issue.

Closes #44 