### PR TITLE
create event probe wizard - event editing

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Event.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Event.java
@@ -42,7 +42,11 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
 
 public class Event implements IEvent {
+	private static final String DEFAULT_STRING_FIELD = "";
+	private static final boolean DEFAULT_BOOLEAN_FIELD = false;
+	private static final Location DEFAULT_LOCATION = Location.WRAP;
 
+	private String id;
 	private String name;
 	private String clazz;
 	private String description;
@@ -55,6 +59,29 @@ public class Event implements IEvent {
 	private List<IMethodParameter> parameters = new ArrayList<>();
 	private IMethodReturnValue returnValue;
 	private List<IField> fields = new ArrayList<>();
+
+	public Event() {
+		id = DEFAULT_STRING_FIELD;
+		name = DEFAULT_STRING_FIELD;
+		clazz = DEFAULT_STRING_FIELD;
+		description = DEFAULT_STRING_FIELD;
+		path = DEFAULT_STRING_FIELD;
+		recordStackTrace = DEFAULT_BOOLEAN_FIELD;
+		useRethrow = DEFAULT_BOOLEAN_FIELD;
+		methodName = DEFAULT_STRING_FIELD;
+		methodDescriptor = DEFAULT_STRING_FIELD;
+		location = DEFAULT_LOCATION;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(String id) {
+		this.id = id;
+	}
 
 	@Override
 	public String getName() {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Event.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Event.java
@@ -172,7 +172,6 @@ public class Event implements IEvent {
 	@Override
 	public void setMethodDescriptor(String methodDescriptor) {
 		this.methodDescriptor = methodDescriptor;
-
 	}
 
 	@Override
@@ -183,13 +182,11 @@ public class Event implements IEvent {
 	@Override
 	public void addMethodParameter(IMethodParameter methodParameter) {
 		parameters.add(methodParameter);
-
 	}
 
 	@Override
 	public void removeMethodParameter(IMethodParameter methodParameter) {
 		parameters.remove(methodParameter);
-
 	}
 
 	@Override
@@ -215,7 +212,6 @@ public class Event implements IEvent {
 	@Override
 	public void addField(IField field) {
 		fields.add(field);
-
 	}
 
 	@Override

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Field.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Field.java
@@ -56,52 +56,42 @@ public class Field implements IField {
 		converter = DEFAULT_STRING_FIELD;
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}
 
-	@Override
 	public void setName(String name) {
 		this.name = name;
 	}
 
-	@Override
 	public String getDescription() {
 		return description;
 	}
 
-	@Override
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
-	@Override
 	public ContentType getContentType() {
 		return contentType;
 	}
 
-	@Override
 	public void setContentType(ContentType contentType) {
 		this.contentType = contentType;
 	}
 
-	@Override
 	public String getRelationKey() {
 		return relationKey;
 	}
 
-	@Override
 	public void setRelationKey(String relationKey) {
 		this.relationKey = relationKey;
 	}
 
-	@Override
 	public String getConverter() {
 		return converter;
 	}
 
-	@Override
 	public void setConverter(String converter) {
 		this.converter = converter;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Field.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/Field.java
@@ -37,12 +37,24 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IField;
 
 public class Field implements IField {
 
+	private static final String DEFAULT_STRING_FIELD = "";
+	private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.NONE;
+
 	private String name;
 	private String description;
 	private ContentType contentType;
 	private String relationKey;
 	private String converter;
 	private String expression;
+
+	public Field() {
+		name = DEFAULT_STRING_FIELD;
+		expression = DEFAULT_STRING_FIELD;
+		description = DEFAULT_STRING_FIELD;
+		contentType = DEFAULT_CONTENT_TYPE;
+		relationKey = DEFAULT_STRING_FIELD;
+		converter = DEFAULT_STRING_FIELD;
+	}
 
 	@Override
 	public String getName() {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodParameter.java
@@ -37,11 +37,25 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
 
 public class MethodParameter implements IMethodParameter {
 
+	private static final String DEFAULT_STRING_FIELD = "";
+	private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.NONE;
+	private static final int DEFAULT_INDEX = 0;
+
 	private String name;
 	private String description;
 	private ContentType contentType;
 	private String relationKey;
 	private String converter;
+	private int index;
+
+	public MethodParameter() {
+		name = DEFAULT_STRING_FIELD;
+		description = DEFAULT_STRING_FIELD;
+		contentType = DEFAULT_CONTENT_TYPE;
+		relationKey = DEFAULT_STRING_FIELD;
+		converter = DEFAULT_STRING_FIELD;
+		index = DEFAULT_INDEX;
+	}
 
 	@Override
 	public String getName() {
@@ -92,6 +106,16 @@ public class MethodParameter implements IMethodParameter {
 	@Override
 	public void setConverter(String converter) {
 		this.converter = converter;
+	}
+
+	@Override
+	public int getIndex() {
+		return index;
+	}
+
+	@Override
+	public void setIndex(int index) {
+		this.index = index;
 	}
 
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodParameter.java
@@ -57,53 +57,42 @@ public class MethodParameter implements IMethodParameter {
 		index = DEFAULT_INDEX;
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}
 
-	@Override
 	public void setName(String name) {
 		this.name = name;
 	}
 
-	@Override
 	public String getDescription() {
 		return description;
 	}
 
-	@Override
 	public void setDescription(String description) {
 		this.description = description;
-
 	}
 
-	@Override
 	public ContentType getContentType() {
 		return contentType;
 	}
 
-	@Override
 	public void setContentType(ContentType contentType) {
 		this.contentType = contentType;
 	}
 
-	@Override
 	public String getRelationKey() {
 		return relationKey;
 	}
 
-	@Override
 	public void setRelationKey(String relationKey) {
 		this.relationKey = relationKey;
 	}
 
-	@Override
 	public String getConverter() {
 		return converter;
 	}
 
-	@Override
 	public void setConverter(String converter) {
 		this.converter = converter;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
@@ -54,42 +54,34 @@ public class MethodReturnValue implements IMethodReturnValue {
 		converter = DEFAULT_STRING_FIELD;
 	}
 
-	@Override
 	public String getDescription() {
 		return description;
 	}
 
-	@Override
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
-	@Override
 	public ContentType getContentType() {
 		return contentType;
 	}
 
-	@Override
 	public void setContentType(ContentType contentType) {
 		this.contentType = contentType;
 	}
 
-	@Override
 	public String getRelationKey() {
 		return relationKey;
 	}
 
-	@Override
 	public void setRelationKey(String relationKey) {
 		this.relationKey = relationKey;
 	}
 
-	@Override
 	public String getConverter() {
 		return converter;
 	}
 
-	@Override
 	public void setConverter(String converter) {
 		this.converter = converter;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
@@ -94,12 +94,10 @@ public class MethodReturnValue implements IMethodReturnValue {
 		this.converter = converter;
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}
 
-	@Override
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/internal/MethodReturnValue.java
@@ -37,10 +37,22 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
 
 public class MethodReturnValue implements IMethodReturnValue {
 
+	private static final String DEFAULT_STRING_FIELD = "";
+	private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.NONE;
+
+	private String name;
 	private String description;
 	private ContentType contentType;
 	private String relationKey;
 	private String converter;
+
+	public MethodReturnValue() {
+		name = DEFAULT_STRING_FIELD;
+		description = DEFAULT_STRING_FIELD;
+		contentType = DEFAULT_CONTENT_TYPE;
+		relationKey = DEFAULT_STRING_FIELD;
+		converter = DEFAULT_STRING_FIELD;
+	}
 
 	@Override
 	public String getDescription() {
@@ -80,6 +92,16 @@ public class MethodReturnValue implements IMethodReturnValue {
 	@Override
 	public void setConverter(String converter) {
 		this.converter = converter;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
 	}
 
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IEvent.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IEvent.java
@@ -39,6 +39,10 @@ public interface IEvent {
 		ENTRY, EXIT, WRAP,
 	}
 
+	String getId();
+
+	void setId(String id);
+
 	String getName();
 
 	void setName(String name);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodParameter.java
@@ -34,4 +34,8 @@
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
 public interface IMethodParameter extends INamedCapturedValue {
+	int getIndex();
+
+	void setIndex(int index);
+
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodReturnValue.java
@@ -33,5 +33,5 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
-public interface IMethodReturnValue extends ICapturedValue {
+public interface IMethodReturnValue extends INamedCapturedValue {
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
@@ -66,12 +66,12 @@ public class EventEditingWizardConfigPage extends WizardPage {
 	private static final String EVENT_DESCRIPTION_LABEL = "Description: ";
 	private static final String EVENT_DESCRIPTION_DESCRIPTION = "Description of this event";
 	private static final String EVENT_CLAZZ_LABEL = "Class: ";
-	private static final String EVENT_CLAZZ_DESCRIPTION = "com.company.project.MyClass";
+	private static final String EVENT_CLAZZ_DESCRIPTION = "com.company.project.MyClass"; // $NON-NLS-1$
 	private static final String EVENT_METHOD_LABEL = "Method: ";
 	private static final String EVENT_METHOD_NAME_DESCRIPTION = "Method Name";
 	private static final String EVENT_DESCRIPTOR_DESCRIPTION = "Descriptor";
 	private static final String EVENT_PATH_LABEL = "Path: ";
-	private static final String EVENT_PATH_DESCRIPTION = "path/to/event";
+	private static final String EVENT_PATH_DESCRIPTION = "path/to/event"; // $NON-NLS-1$
 	private static final String EVENT_LOCATION_LABEL = "Location: ";
 	private static final String EVENT_RETHROW_LABEL = "Catch any expression and rethrow";
 	private static final String EVENT_STACKTRACE_LABEL = "Record Stack Trace";
@@ -179,7 +179,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 	}
 
 	private void createMethodSection(Composite parent) {
-
 		GridData gdLabel = new GridData(SWT.BEGINNING, SWT.CENTER, false, false);
 		GridData gdText = new GridData(SWT.FILL, SWT.CENTER, true, true);
 		gdText.minimumWidth = 0;
@@ -287,7 +286,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 
 	private void bindListeners() {
 		idText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setId(idText.getText());
@@ -295,7 +293,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		nameText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setName(nameText.getText());
@@ -303,7 +300,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		descriptionText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setDescription(descriptionText.getText());
@@ -311,7 +307,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		methodNameText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setMethodName(methodNameText.getText());
@@ -319,7 +314,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		methodDescriptorText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setMethodDescriptor(methodDescriptorText.getText());
@@ -327,7 +321,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		pathText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setMethodName(pathText.getText());
@@ -335,7 +328,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		clazzText.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				event.setClazz(clazzText.getText());
@@ -357,7 +349,6 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		});
 
 		locationCombo.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				if (locationCombo.getSelectionIndex() >= 0) {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
@@ -59,6 +59,22 @@ public class EventEditingWizardConfigPage extends WizardPage {
 	private static final String PAGE_NAME = "Agent Event Editing";
 	private static final String MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE = "Editing Event Configurations";
 	private static final String MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION = "Edit basic information of an event on how it should be instrumented and injected.";
+	private static final String EVENT_ID_LABEL = "ID: ";
+	private static final String EVENT_ID_DESCRIPTION = "Event ID";
+	private static final String EVENT_NAME_LABEL = "Name: ";
+	private static final String EVENT_NAME_DESCRIPTION = "Name of the Event";
+	private static final String EVENT_DESCRIPTION_LABEL = "Description: ";
+	private static final String EVENT_DESCRIPTION_DESCRIPTION = "Description of this event";
+	private static final String EVENT_CLAZZ_LABEL = "Class: ";
+	private static final String EVENT_CLAZZ_DESCRIPTION = "com.company.project.MyClass";
+	private static final String EVENT_METHOD_LABEL = "Method: ";
+	private static final String EVENT_METHOD_NAME_DESCRIPTION = "Method Name";
+	private static final String EVENT_DESCRIPTOR_DESCRIPTION = "Descriptor";
+	private static final String EVENT_PATH_LABEL = "Path: ";
+	private static final String EVENT_PATH_DESCRIPTION = "path/to/event";
+	private static final String EVENT_LOCATION_LABEL = "Location: ";
+	private static final String EVENT_RETHROW_LABEL = "Catch any expression and rethrow";
+	private static final String EVENT_STACKTRACE_LABEL = "Record Stack Trace";
 
 	private static final int NUM_COLUMNS = 3;
 
@@ -127,21 +143,21 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		gdText.widthHint = 300;
 		gdText.horizontalSpan = NUM_COLUMNS - 1;
 
-		Label label = createLabel(parent, "ID:");
+		Label label = createLabel(parent, EVENT_ID_LABEL);
 		label.setLayoutData(gdLabel);
 
 		idText = createText(parent);
-		idText.setMessage("Event ID");
+		idText.setMessage(EVENT_ID_DESCRIPTION);
 		idText.setLayoutData(gdText);
 
-		label = createLabel(parent, "Name:");
+		label = createLabel(parent, EVENT_NAME_LABEL);
 		label.setLayoutData(gdLabel);
 
 		nameText = createText(parent);
-		nameText.setMessage("Name of the Event");
+		nameText.setMessage(EVENT_NAME_DESCRIPTION);
 		nameText.setLayoutData(gdText);
 
-		label = createLabel(parent, "Description:");
+		label = createLabel(parent, EVENT_DESCRIPTION_LABEL);
 		label.setLayoutData(gdLabel);
 
 		gdText = new GridData(SWT.FILL, SWT.CENTER, true, true);
@@ -151,7 +167,7 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		gdText.horizontalSpan = NUM_COLUMNS;
 
 		descriptionText = createTextMulti(parent);
-		descriptionText.setMessage("Description of this event");
+		descriptionText.setMessage(EVENT_DESCRIPTION_DESCRIPTION);
 		descriptionText.setLayoutData(gdText);
 
 		Control separator = createSeparator(parent);
@@ -170,14 +186,14 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		gdText.widthHint = 300;
 		gdText.horizontalSpan = NUM_COLUMNS - 1;
 
-		Label label = createLabel(parent, "Class:");
+		Label label = createLabel(parent, EVENT_CLAZZ_LABEL);
 		label.setLayoutData(gdLabel);
 
 		clazzText = createText(parent);
-		clazzText.setMessage("com.company.project.MyClass");
+		clazzText.setMessage(EVENT_CLAZZ_DESCRIPTION);
 		clazzText.setLayoutData(gdText);
 
-		label = createLabel(parent, "Method:");
+		label = createLabel(parent, EVENT_METHOD_LABEL);
 		label.setLayoutData(gdLabel);
 
 		gdText = new GridData(SWT.FILL, SWT.CENTER, true, true);
@@ -186,11 +202,11 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		gdText.horizontalSpan = NUM_COLUMNS - 2;
 
 		methodNameText = createText(parent);
-		methodNameText.setMessage("Method Name");
+		methodNameText.setMessage(EVENT_METHOD_NAME_DESCRIPTION);
 		methodNameText.setLayoutData(gdText);
 
 		methodDescriptorText = createText(parent);
-		methodDescriptorText.setMessage("Descriptor");
+		methodDescriptorText.setMessage(EVENT_DESCRIPTOR_DESCRIPTION);
 		methodDescriptorText.setLayoutData(gdText);
 
 		Control separator = createSeparator(parent);
@@ -207,14 +223,14 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		gdText.widthHint = 300;
 		gdText.horizontalSpan = NUM_COLUMNS - 1;
 
-		Label label = createLabel(parent, "Path:");
+		Label label = createLabel(parent, EVENT_PATH_LABEL);
 		label.setLayoutData(gdLabel);
 
 		pathText = createText(parent);
-		pathText.setMessage("path/to/event");
+		pathText.setMessage(EVENT_PATH_DESCRIPTION);
 		pathText.setLayoutData(gdText);
 
-		label = createLabel(parent, "Location:");
+		label = createLabel(parent, EVENT_LOCATION_LABEL);
 		label.setLayoutData(gdLabel);
 
 		locationCombo = new Combo(parent, SWT.DROP_DOWN | SWT.READ_ONLY);
@@ -235,13 +251,13 @@ public class EventEditingWizardConfigPage extends WizardPage {
 
 		GridData gdLabel = new GridData(SWT.FILL, SWT.CENTER, true, true);
 
-		Label label = createLabel(checkBoxTextContainer, "Catch any expression and rethrow");
+		Label label = createLabel(checkBoxTextContainer, EVENT_RETHROW_LABEL);
 		label.setLayoutData(gdLabel);
 
 		recordStackTraceBtn = new Button(checkBoxTextContainer, SWT.CHECK);
 		recordStackTraceBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 
-		label = createLabel(checkBoxTextContainer, "Record Stack Trace");
+		label = createLabel(checkBoxTextContainer, EVENT_STACKTRACE_LABEL);
 		label.setLayoutData(gdLabel);
 
 		checkBoxTextContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
@@ -40,17 +40,13 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent.Location;
@@ -73,8 +69,8 @@ public class EventEditingWizardConfigPage extends WizardPage {
 	private static final String EVENT_PATH_LABEL = "Path: ";
 	private static final String EVENT_PATH_DESCRIPTION = "path/to/event"; // $NON-NLS-1$
 	private static final String EVENT_LOCATION_LABEL = "Location: ";
-	private static final String EVENT_RETHROW_LABEL = "Catch any expression and rethrow";
-	private static final String EVENT_STACKTRACE_LABEL = "Record Stack Trace";
+	private static final String EVENT_RETHROW_LABEL = "Record exceptions";
+	private static final String EVENT_STACKTRACE_LABEL = "Record stack trace";
 
 	private static final int NUM_COLUMNS = 3;
 
@@ -171,11 +167,10 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		descriptionText.setLayoutData(gdText);
 
 		Control separator = createSeparator(parent);
-		GridData gdSeperator = new GridData(SWT.FILL, SWT.FILL, true, false);
-		gdSeperator.horizontalSpan = NUM_COLUMNS;
-		gdSeperator.heightHint = 20;
-		separator.setLayoutData(gdSeperator);
-
+		GridData gdSeparator = new GridData(SWT.FILL, SWT.FILL, true, false);
+		gdSeparator.horizontalSpan = NUM_COLUMNS;
+		gdSeparator.heightHint = 20;
+		separator.setLayoutData(gdSeparator);
 	}
 
 	private void createMethodSection(Composite parent) {
@@ -209,10 +204,10 @@ public class EventEditingWizardConfigPage extends WizardPage {
 		methodDescriptorText.setLayoutData(gdText);
 
 		Control separator = createSeparator(parent);
-		GridData gdSeperator = new GridData(SWT.FILL, SWT.FILL, true, false);
-		gdSeperator.horizontalSpan = NUM_COLUMNS;
-		gdSeperator.heightHint = 20;
-		separator.setLayoutData(gdSeperator);
+		GridData gdSeparator = new GridData(SWT.FILL, SWT.FILL, true, false);
+		gdSeparator.horizontalSpan = NUM_COLUMNS;
+		gdSeparator.heightHint = 20;
+		separator.setLayoutData(gdSeparator);
 	}
 
 	private void createOtherInfoSection(Composite parent) {
@@ -243,21 +238,15 @@ public class EventEditingWizardConfigPage extends WizardPage {
 
 	private void createCheckBoxSection(Composite parent) {
 		Composite checkBoxTextContainer = new Composite(parent, SWT.NONE);
-		checkBoxTextContainer.setLayout(new GridLayout(2, false));
+		checkBoxTextContainer.setLayout(new GridLayout());
 
 		useRethrowBtn = new Button(checkBoxTextContainer, SWT.CHECK);
+		useRethrowBtn.setText(EVENT_RETHROW_LABEL);
 		useRethrowBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 
-		GridData gdLabel = new GridData(SWT.FILL, SWT.CENTER, true, true);
-
-		Label label = createLabel(checkBoxTextContainer, EVENT_RETHROW_LABEL);
-		label.setLayoutData(gdLabel);
-
 		recordStackTraceBtn = new Button(checkBoxTextContainer, SWT.CHECK);
+		recordStackTraceBtn.setText(EVENT_STACKTRACE_LABEL);
 		recordStackTraceBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
-
-		label = createLabel(checkBoxTextContainer, EVENT_STACKTRACE_LABEL);
-		label.setLayoutData(gdLabel);
 
 		checkBoxTextContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 	}
@@ -285,77 +274,16 @@ public class EventEditingWizardConfigPage extends WizardPage {
 	}
 
 	private void bindListeners() {
-		idText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setId(idText.getText());
-			}
-		});
-
-		nameText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setName(nameText.getText());
-			}
-		});
-
-		descriptionText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setDescription(descriptionText.getText());
-			}
-		});
-
-		methodNameText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setMethodName(methodNameText.getText());
-			}
-		});
-
-		methodDescriptorText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setMethodDescriptor(methodDescriptorText.getText());
-			}
-		});
-
-		pathText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setMethodName(pathText.getText());
-			}
-		});
-
-		clazzText.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				event.setClazz(clazzText.getText());
-			}
-		});
-
-		useRethrowBtn.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event e) {
-				event.setRethrow(useRethrowBtn.getSelection());
-			}
-		});
-
-		recordStackTraceBtn.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event e) {
-				event.setStackTrace(recordStackTraceBtn.getSelection());
-			}
-		});
-
-		locationCombo.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				if (locationCombo.getSelectionIndex() >= 0) {
-					event.setLocation(Location.valueOf(locationCombo.getText()));
-				}
-			}
-		});
+		idText.addModifyListener(e -> event.setId(idText.getText()));
+		nameText.addModifyListener(e -> event.setName(nameText.getText()));
+		descriptionText.addModifyListener(e -> event.setDescription(descriptionText.getText()));
+		methodNameText.addModifyListener(e -> event.setMethodName(methodNameText.getText()));
+		methodDescriptorText.addModifyListener(e -> event.setMethodDescriptor(methodDescriptorText.getText()));
+		pathText.addModifyListener(e -> event.setMethodName(pathText.getText()));
+		clazzText.addModifyListener(e -> event.setClazz(clazzText.getText()));
+		useRethrowBtn.addListener(SWT.Selection, e -> event.setRethrow(useRethrowBtn.getSelection()));
+		recordStackTraceBtn.addListener(SWT.Selection, e -> event.setStackTrace(recordStackTraceBtn.getSelection()));
+		locationCombo.addModifyListener(e -> event.setLocation(Location.valueOf(locationCombo.getText())));
 	}
 
 	private void populateStoredValues() {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
@@ -41,6 +41,7 @@ import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.openjdk.jmc.console.ext.agent.manager.internal.Field;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IField;
@@ -79,9 +80,9 @@ public class EventEditingWizardFieldPage extends WizardPage {
 		tableInspector.setInput(event.getFields());
 
 		tableButtons = new TableButtonControls(container, tableInspector.getViewer());
-		tableButtons.setAddButtonListener(() -> onAddBtnPressed());
-		tableButtons.setEditButtonListener(() -> onEditBtnPressed());
-		tableButtons.setRemoveButtonListener(() -> onRemoveBtnPressed());
+		tableButtons.setAddButtonListener(this::onAddBtnPressed);
+		tableButtons.setEditButtonListener(this::onEditBtnPressed);
+		tableButtons.setRemoveButtonListener(this::onRemoveBtnPressed);
 
 		sc.setExpandHorizontal(true);
 		sc.setExpandVertical(true);
@@ -92,7 +93,7 @@ public class EventEditingWizardFieldPage extends WizardPage {
 	private void onAddBtnPressed() {
 		IField field = new Field();
 		EventFieldEditingPage page = new EventFieldEditingPage(field);
-		OnePageWizardDialog.open(page, 600, 600);
+		new OnePageWizardDialog(Display.getCurrent().getActiveShell(), page).open();
 		event.addField(field);
 		tableInspector.setInput(event.getFields());
 	}
@@ -102,7 +103,7 @@ public class EventEditingWizardFieldPage extends WizardPage {
 		if (itemInfo == null) {
 			return;
 		}
-		OnePageWizardDialog.open(new EventFieldEditingPage(itemInfo), 600, 600);
+		new OnePageWizardDialog(Display.getCurrent().getActiveShell(), new EventFieldEditingPage(itemInfo)).open();
 		tableInspector.setInput(event.getFields());
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.openjdk.jmc.console.ext.agent.manager.internal.MethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.ICapturedValue;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
@@ -84,9 +85,9 @@ public class EventEditingWizardParameterPage extends WizardPage {
 		tableInspector.setInput(populateTable());
 
 		tableButtons = new TableButtonControls(container, tableInspector.getViewer());
-		tableButtons.setAddButtonListener(() -> onAddBtnPressed());
-		tableButtons.setEditButtonListener(() -> onEditBtnPressed());
-		tableButtons.setRemoveButtonListener(() -> onRemoveBtnPressed());
+		tableButtons.setAddButtonListener(this::onAddBtnPressed);
+		tableButtons.setEditButtonListener(this::onEditBtnPressed);
+		tableButtons.setRemoveButtonListener(this::onRemoveBtnPressed);
 
 		sc.setExpandHorizontal(true);
 		sc.setExpandVertical(true);
@@ -96,7 +97,7 @@ public class EventEditingWizardParameterPage extends WizardPage {
 
 	private void onAddBtnPressed() {
 		EventMethodParameterEditingPage page = new EventMethodParameterEditingPage();
-		OnePageWizardDialog.open(page, 600, 600);
+		new OnePageWizardDialog(Display.getCurrent().getActiveShell(), page).open();
 		ICapturedValue capturedValue = page.getCapturedValue();
 		if (capturedValue instanceof MethodParameter) {
 			event.addMethodParameter((IMethodParameter) capturedValue);
@@ -111,7 +112,8 @@ public class EventEditingWizardParameterPage extends WizardPage {
 		if (itemInfo == null) {
 			return;
 		}
-		OnePageWizardDialog.open(new EventMethodParameterEditingPage(itemInfo), 600, 600);
+		new OnePageWizardDialog(Display.getCurrent().getActiveShell(), new EventMethodParameterEditingPage(itemInfo))
+				.open();
 
 		tableInspector.setInput(populateTable());
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
@@ -63,9 +63,9 @@ public class EventFieldEditingPage extends WizardPage {
 	private static final String FIELD_DESCRIPTION_DESCRIPTION = "Description of field";
 	private static final String FIELD_CONTENT_TYPE_LABEL = "Content Type: ";
 	private static final String FIELD_RELATIONAL_KEY_LABEL = "Relational Key: ";
-	private static final String FIELD_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri";
+	private static final String FIELD_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri"; // $NON-NLS-1$
 	private static final String FIELD_CONVERTER_TYPE_LABEL = "Converter Type: ";
-	private static final String FIELD_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter";
+	private static final String FIELD_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter"; // $NON-NLS-1$
 
 	private Text name;
 	private Text expression;
@@ -199,7 +199,6 @@ public class EventFieldEditingPage extends WizardPage {
 
 	private void bindListeners() {
 		converterType.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				field.setConverter(converterType.getText());
@@ -207,7 +206,6 @@ public class EventFieldEditingPage extends WizardPage {
 		});
 
 		description.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				field.setDescription(description.getText());
@@ -215,7 +213,6 @@ public class EventFieldEditingPage extends WizardPage {
 		});
 
 		relationalKey.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				field.setRelationKey(relationalKey.getText());
@@ -223,7 +220,6 @@ public class EventFieldEditingPage extends WizardPage {
 		});
 
 		name.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				field.setName(name.getText());
@@ -240,7 +236,6 @@ public class EventFieldEditingPage extends WizardPage {
 		});
 
 		contentType.addModifyListener(new ModifyListener() {
-
 			@Override
 			public void modifyText(ModifyEvent e) {
 				if (contentType.getSelectionIndex() >= 0) {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
@@ -55,6 +55,18 @@ public class EventFieldEditingPage extends WizardPage {
 	private static final String PAGE_NAME = "Agent Parameter Editing";
 	private static final String MESSAGE_FIELD_EDITING_PAGE_TITLE = "Editing a Field";
 	private static final String MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION = "Define a custom evaluation and capturing with an expression";
+	private static final String FIELD_NAME_LABEL = "Name: ";
+	private static final String FIELD_NAME_DESCRIPTION = "Field Name";
+	private static final String FIELD_EXPRESSION_LABEL = "Expression: ";
+	private static final String FIELD_EXPRESSION_DESCRIPTION = "Expression to capture";
+	private static final String FIELD_DESCRIPTION_LABEL = "Description: ";
+	private static final String FIELD_DESCRIPTION_DESCRIPTION = "Description of field";
+	private static final String FIELD_CONTENT_TYPE_LABEL = "Content Type: ";
+	private static final String FIELD_RELATIONAL_KEY_LABEL = "Relational Key: ";
+	private static final String FIELD_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri";
+	private static final String FIELD_CONVERTER_TYPE_LABEL = "Converter Type: ";
+	private static final String FIELD_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter";
+
 	private Text name;
 	private Text expression;
 	private Text description;
@@ -105,21 +117,21 @@ public class EventFieldEditingPage extends WizardPage {
 		gdText.minimumWidth = 0;
 		gdText.widthHint = 300;
 
-		Label label = createLabel(parent, "Name:");
+		Label label = createLabel(parent, FIELD_NAME_LABEL);
 		label.setLayoutData(gdLabel);
 
 		name = createText(parent);
-		name.setMessage("Field Name");
+		name.setMessage(FIELD_NAME_DESCRIPTION);
 		name.setLayoutData(gdText);
 
-		label = createLabel(parent, "Expression:");
+		label = createLabel(parent, FIELD_EXPRESSION_LABEL);
 		label.setLayoutData(gdLabel);
 
 		expression = createText(parent);
-		expression.setMessage("Expression to capture");
+		expression.setMessage(FIELD_EXPRESSION_DESCRIPTION);
 		expression.setLayoutData(gdText);
 
-		label = createLabel(parent, "Description:");
+		label = createLabel(parent, FIELD_DESCRIPTION_LABEL);
 		label.setLayoutData(gdLabel);
 
 		GridData largeText = new GridData(SWT.FILL, SWT.CENTER, true, true);
@@ -129,10 +141,10 @@ public class EventFieldEditingPage extends WizardPage {
 		largeText.horizontalSpan = 2;
 
 		description = createTextMulti(parent);
-		description.setMessage("Description of field");
+		description.setMessage(FIELD_DESCRIPTION_DESCRIPTION);
 		description.setLayoutData(largeText);
 
-		label = createLabel(parent, "Content Type:");
+		label = createLabel(parent, FIELD_CONTENT_TYPE_LABEL);
 		label.setLayoutData(gdLabel);
 
 		contentType = new Combo(parent, SWT.DROP_DOWN | SWT.READ_ONLY);
@@ -143,18 +155,18 @@ public class EventFieldEditingPage extends WizardPage {
 		contentType.setItems(contentTypes.toArray(new String[0]));
 		contentType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		label = createLabel(parent, "Relational Key:");
+		label = createLabel(parent, FIELD_RELATIONAL_KEY_LABEL);
 		label.setLayoutData(gdLabel);
 
 		relationalKey = createText(parent);
-		relationalKey.setMessage("schema://some-uri");
+		relationalKey.setMessage(FIELD_RELATIONAL_KEY_DESCRIPTION);
 		relationalKey.setLayoutData(gdText);
 
-		label = createLabel(parent, "Converter Type:");
+		label = createLabel(parent, FIELD_CONVERTER_TYPE_LABEL);
 		label.setLayoutData(gdLabel);
 
 		converterType = createText(parent);
-		converterType.setMessage("com.company.project.MyConverter");
+		converterType.setMessage(FIELD_CONVERTER_TYPE_DESCRIPTION);
 		converterType.setLayoutData(gdText);
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventFieldEditingPage.java
@@ -39,8 +39,6 @@ import java.util.List;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Combo;
@@ -102,7 +100,7 @@ public class EventFieldEditingPage extends WizardPage {
 		createPageContent(gridSection);
 		gridSection.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		popuateStoredValues();
+		populateStoredValues();
 		bindListeners();
 
 		sc.setExpandHorizontal(true);
@@ -188,7 +186,7 @@ public class EventFieldEditingPage extends WizardPage {
 		return text;
 	}
 
-	private void popuateStoredValues() {
+	private void populateStoredValues() {
 		converterType.setText(field.getConverter());
 		description.setText(field.getDescription());
 		relationalKey.setText(field.getRelationKey());
@@ -198,51 +196,12 @@ public class EventFieldEditingPage extends WizardPage {
 	}
 
 	private void bindListeners() {
-		converterType.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				field.setConverter(converterType.getText());
-			}
-		});
-
-		description.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				field.setDescription(description.getText());
-			}
-		});
-
-		relationalKey.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				field.setRelationKey(relationalKey.getText());
-			}
-		});
-
-		name.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				field.setName(name.getText());
-
-			}
-		});
-
-		expression.addModifyListener(new ModifyListener() {
-
-			@Override
-			public void modifyText(ModifyEvent e) {
-				field.setExpression(expression.getText());
-			}
-		});
-
-		contentType.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				if (contentType.getSelectionIndex() >= 0) {
-					field.setContentType(ICapturedValue.ContentType.valueOf(contentType.getText()));
-				}
-			}
-		});
-
+		converterType.addModifyListener(e -> field.setConverter(converterType.getText()));
+		description.addModifyListener(e -> field.setDescription(description.getText()));
+		relationalKey.addModifyListener(e -> field.setRelationKey(relationalKey.getText()));
+		name.addModifyListener(e -> field.setName(name.getText()));
+		expression.addModifyListener(e -> field.setExpression(expression.getText()));
+		contentType.addModifyListener(
+				e -> field.setContentType(ICapturedValue.ContentType.valueOf(contentType.getText())));
 	}
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
@@ -44,9 +44,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.console.ext.agent.manager.internal.MethodParameter;
@@ -141,28 +139,18 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 		label.setLayoutData(gdLabel);
 
 		Composite indexContainer = new Composite(parent, SWT.NONE);
-		indexContainer.setLayout(new GridLayout(3, false));
+		GridLayout gl = new GridLayout(2, false);
+		gl.marginWidth = 0;
+		indexContainer.setLayout(gl);
 		indexContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
 		index = new Spinner(indexContainer, SWT.NONE);
 		index.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		label = createLabel(indexContainer, RETURN_VALUE_LABEL);
-		label.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, true));
-
 		returnValueBtn = new Button(indexContainer, SWT.CHECK);
-		returnValueBtn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
-		returnValueBtn.addListener(SWT.Selection, new Listener() {
-
-			@Override
-			public void handleEvent(Event event) {
-				if (returnValueBtn.getSelection()) {
-					index.setEnabled(false);
-				} else {
-					index.setEnabled(true);
-				}
-			}
-		});
+		returnValueBtn.setText(RETURN_VALUE_LABEL);
+		returnValueBtn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		returnValueBtn.addListener(SWT.Selection, e -> index.setEnabled(!returnValueBtn.getSelection()));
 
 		label = createLabel(parent, PARAM_DESCRIPTION_LABEL);
 		label.setLayoutData(gdLabel);
@@ -235,7 +223,7 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 			returnValueBtn.setEnabled(false);
 		} else {
 			index.setEnabled(false);
-			returnValueBtn.setSelection(true);
+			returnValueBtn.setSelection(false);
 		}
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
@@ -68,9 +68,9 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 	private static final String PARAM_DESCRIPTION_DESCRIPTION = "Description of this parameter or return value";
 	private static final String PARAM_CONTENT_TYPE_LABEL = "Content Type: ";
 	private static final String PARAM_RELATIONAL_KEY_LABEL = "Relational Key: ";
-	private static final String PARAM_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri";
+	private static final String PARAM_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri"; // $NON-NLS-1$
 	private static final String PARAM_CONVERTER_TYPE_LABEL = "Converter Type: ";
-	private static final String PARAM_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter";
+	private static final String PARAM_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter"; // $NON-NLS-1$
 
 	private ICapturedValue capturedValue;
 	private Text name;
@@ -161,9 +161,7 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 				} else {
 					index.setEnabled(true);
 				}
-
 			}
-
 		});
 
 		label = createLabel(parent, PARAM_DESCRIPTION_LABEL);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventMethodParameterEditingPage.java
@@ -60,6 +60,18 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 	private static final String PAGE_NAME = "Agent Parameter Editing";
 	private static final String MESSAGE_PRESET_MANAGER_PAGE_TITLE = "Edit a Parameter or Return Value Capturing";
 	private static final String MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION = "Define the capturing of a parameter or return value by its index.";
+	private static final String PARAM_NAME_LABEL = "Name: ";
+	private static final String PARAM_NAME_DESCRIPTION = "Parameter or Return Value Name";
+	private static final String PARAM_INDEX_LABEL = "Index: ";
+	private static final String RETURN_VALUE_LABEL = "This is a return value";
+	private static final String PARAM_DESCRIPTION_LABEL = "Description: ";
+	private static final String PARAM_DESCRIPTION_DESCRIPTION = "Description of this parameter or return value";
+	private static final String PARAM_CONTENT_TYPE_LABEL = "Content Type: ";
+	private static final String PARAM_RELATIONAL_KEY_LABEL = "Relational Key: ";
+	private static final String PARAM_RELATIONAL_KEY_DESCRIPTION = "schema://some-uri";
+	private static final String PARAM_CONVERTER_TYPE_LABEL = "Converter Type: ";
+	private static final String PARAM_CONVERTER_TYPE_DESCRIPTION = "com.company.project.MyConverter";
+
 	private ICapturedValue capturedValue;
 	private Text name;
 	private Spinner index;
@@ -118,14 +130,14 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 		gdText.minimumWidth = 0;
 		gdText.widthHint = 300;
 
-		Label label = createLabel(parent, "Name:");
+		Label label = createLabel(parent, PARAM_NAME_LABEL);
 		label.setLayoutData(gdLabel);
 
 		name = createText(parent);
-		name.setMessage("Parameter or Return Value Name");
+		name.setMessage(PARAM_NAME_DESCRIPTION);
 		name.setLayoutData(gdText);
 
-		label = createLabel(parent, "Index:");
+		label = createLabel(parent, PARAM_INDEX_LABEL);
 		label.setLayoutData(gdLabel);
 
 		Composite indexContainer = new Composite(parent, SWT.NONE);
@@ -135,7 +147,7 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 		index = new Spinner(indexContainer, SWT.NONE);
 		index.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		label = createLabel(indexContainer, "This is a return value");
+		label = createLabel(indexContainer, RETURN_VALUE_LABEL);
 		label.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, true));
 
 		returnValueBtn = new Button(indexContainer, SWT.CHECK);
@@ -145,7 +157,6 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 			@Override
 			public void handleEvent(Event event) {
 				if (returnValueBtn.getSelection()) {
-					//index.deselectAll();
 					index.setEnabled(false);
 				} else {
 					index.setEnabled(true);
@@ -155,7 +166,7 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 
 		});
 
-		label = createLabel(parent, "Description:");
+		label = createLabel(parent, PARAM_DESCRIPTION_LABEL);
 		label.setLayoutData(gdLabel);
 
 		GridData largeText = new GridData(SWT.FILL, SWT.CENTER, true, true);
@@ -165,10 +176,10 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 		largeText.horizontalSpan = 2;
 
 		description = createTextMulti(parent);
-		description.setMessage("Description of this parameter or return value");
+		description.setMessage(PARAM_DESCRIPTION_DESCRIPTION);
 		description.setLayoutData(largeText);
 
-		label = createLabel(parent, "Content Type:");
+		label = createLabel(parent, PARAM_CONTENT_TYPE_LABEL);
 		label.setLayoutData(gdLabel);
 
 		contentType = new Combo(parent, SWT.DROP_DOWN | SWT.READ_ONLY);
@@ -179,18 +190,18 @@ public class EventMethodParameterEditingPage extends WizardPage implements IPerf
 		contentType.setItems(contentTypes.toArray(new String[0]));
 		contentType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		label = createLabel(parent, "Relational Key:");
+		label = createLabel(parent, PARAM_RELATIONAL_KEY_LABEL);
 		label.setLayoutData(gdLabel);
 
 		relationalKey = createText(parent);
-		relationalKey.setMessage("schema://some-uri");
+		relationalKey.setMessage(PARAM_RELATIONAL_KEY_DESCRIPTION);
 		relationalKey.setLayoutData(gdText);
 
-		label = createLabel(parent, "Converter Type:");
+		label = createLabel(parent, PARAM_CONVERTER_TYPE_LABEL);
 		label.setLayoutData(gdLabel);
 
 		converterType = createText(parent);
-		converterType.setMessage("com.company.project.MyConverter");
+		converterType.setMessage(PARAM_CONVERTER_TYPE_DESCRIPTION);
 		converterType.setLayoutData(gdText);
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
@@ -37,12 +37,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
-import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
-import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TableViewer;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Tree;
 import org.openjdk.jmc.console.ext.agent.manager.model.IField;
 import org.openjdk.jmc.ui.column.ColumnBuilder;
 import org.openjdk.jmc.ui.column.ColumnManager;
@@ -60,7 +59,7 @@ public class FieldTableInspector {
 	private static final String DESCRIPTION_COLUNM_ID = "description";
 	private static final String DESCRIPTION_COLUNM_NAME = "Description";
 
-	private final TreeViewer viewer;
+	private final TableViewer viewer;
 
 	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
 		@Override
@@ -93,14 +92,11 @@ public class FieldTableInspector {
 	};
 
 	public FieldTableInspector(Composite parent) {
-		Tree tree = new Tree(parent,
-				SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
-		tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		viewer = new TreeViewer(tree);
+		viewer = new TableViewer(parent, SWT.V_SCROLL | SWT.BORDER | SWT.FULL_SELECTION);
+		viewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		viewer.setContentProvider(new TreeStructureContentProvider());
-		ColumnViewerToolTipSupport.enableFor(viewer);
+		viewer.getTable().setHeaderVisible(true);
 
-		tree.setData("name", FIELD_TREE_NAME); //$NON-NLS-1$
 		List<IColumn> columns = new ArrayList<>();
 		columns.add(new ColumnBuilder(NAME_COLUNM_NAME, NAME_COLUNM_ID, nameLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(nameLabelProvider)).build());
@@ -116,7 +112,7 @@ public class FieldTableInspector {
 		viewer.setInput(input);
 	}
 
-	public TreeViewer getViewer() {
+	public TableViewer getViewer() {
 		return viewer;
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
@@ -50,8 +50,6 @@ import org.openjdk.jmc.ui.misc.OptimisticComparator;
 import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 
 public class FieldTableInspector {
-
-	public static final String FIELD_TREE_NAME = "EventEditingWizardFieldPage.FieldsTree"; //$NON-NLS-1$
 	private static final String NAME_COLUNM_ID = "name";
 	private static final String NAME_COLUNM_NAME = "Name";
 	private static final String EXPRESSION_COLUNM_ID = "expression";

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
@@ -53,6 +53,12 @@ import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 public class FieldTableInspector {
 
 	public static final String FIELD_TREE_NAME = "EventEditingWizardFieldPage.FieldsTree"; //$NON-NLS-1$
+	private static final String NAME_COLUNM_ID = "name";
+	private static final String NAME_COLUNM_NAME = "Name";
+	private static final String EXPRESSION_COLUNM_ID = "expression";
+	private static final String EXPRESSION_COLUNM_NAME = "Expression";
+	private static final String DESCRIPTION_COLUNM_ID = "description";
+	private static final String DESCRIPTION_COLUNM_NAME = "Description";
 
 	private final TreeViewer viewer;
 
@@ -96,12 +102,13 @@ public class FieldTableInspector {
 
 		tree.setData("name", FIELD_TREE_NAME); //$NON-NLS-1$
 		List<IColumn> columns = new ArrayList<>();
-		columns.add(new ColumnBuilder("Name", "name", nameLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(NAME_COLUNM_NAME, NAME_COLUNM_ID, nameLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(nameLabelProvider)).build());
-		columns.add(new ColumnBuilder("Expression", "expression", expressionLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(EXPRESSION_COLUNM_NAME, EXPRESSION_COLUNM_ID, expressionLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(expressionLabelProvider)).build());
-		columns.add(new ColumnBuilder("Description", "description", descriptionLabelProvider).comparator(//$NON-NLS-1$
-				new OptimisticComparator(descriptionLabelProvider)).build());
+		columns.add(
+				new ColumnBuilder(DESCRIPTION_COLUNM_NAME, DESCRIPTION_COLUNM_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
+						new OptimisticComparator(descriptionLabelProvider)).build());
 		ColumnManager.build(viewer, columns, null);
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.manager.wizards;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Tree;
+import org.openjdk.jmc.console.ext.agent.manager.model.IField;
+import org.openjdk.jmc.ui.column.ColumnBuilder;
+import org.openjdk.jmc.ui.column.ColumnManager;
+import org.openjdk.jmc.ui.column.IColumn;
+import org.openjdk.jmc.ui.misc.OptimisticComparator;
+import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
+
+public class FieldTableInspector {
+
+	public static final String FIELD_TREE_NAME = "EventEditingWizardFieldPage.FieldsTree"; //$NON-NLS-1$
+
+	private final TreeViewer viewer;
+
+	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof IField) {
+				return ((IField) element).getName();
+			}
+			return element.toString();
+		}
+	};
+
+	private final ColumnLabelProvider expressionLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof IField) {
+				return ((IField) element).getExpression();
+			}
+			return element.toString();
+		}
+	};
+
+	private final ColumnLabelProvider descriptionLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof IField) {
+				return ((IField) element).getDescription();
+			}
+			return element.toString();
+		}
+	};
+
+	public FieldTableInspector(Composite parent) {
+		Tree tree = new Tree(parent,
+				SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
+		tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		viewer = new TreeViewer(tree);
+		viewer.setContentProvider(new TreeStructureContentProvider());
+		ColumnViewerToolTipSupport.enableFor(viewer);
+
+		tree.setData("name", FIELD_TREE_NAME); //$NON-NLS-1$
+		List<IColumn> columns = new ArrayList<>();
+		columns.add(new ColumnBuilder("Name", "name", nameLabelProvider).comparator( //$NON-NLS-1$
+				new OptimisticComparator(nameLabelProvider)).build());
+		columns.add(new ColumnBuilder("Expression", "expression", expressionLabelProvider).comparator( //$NON-NLS-1$
+				new OptimisticComparator(expressionLabelProvider)).build());
+		columns.add(new ColumnBuilder("Description", "description", descriptionLabelProvider).comparator(//$NON-NLS-1$
+				new OptimisticComparator(descriptionLabelProvider)).build());
+		ColumnManager.build(viewer, columns, null);
+	}
+
+	public void setInput(Object input) {
+		viewer.setInput(input);
+	}
+
+	public TreeViewer getViewer() {
+		return viewer;
+	}
+
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/FieldTableInspector.java
@@ -50,12 +50,12 @@ import org.openjdk.jmc.ui.misc.OptimisticComparator;
 import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 
 public class FieldTableInspector {
-	private static final String NAME_COLUNM_ID = "name";
-	private static final String NAME_COLUNM_NAME = "Name";
-	private static final String EXPRESSION_COLUNM_ID = "expression";
-	private static final String EXPRESSION_COLUNM_NAME = "Expression";
-	private static final String DESCRIPTION_COLUNM_ID = "description";
-	private static final String DESCRIPTION_COLUNM_NAME = "Description";
+	private static final String NAME_COLUMN_ID = "name";
+	private static final String NAME_COLUMN_NAME = "Name";
+	private static final String EXPRESSION_COLUMN_ID = "expression";
+	private static final String EXPRESSION_COLUMN_NAME = "Expression";
+	private static final String DESCRIPTION_COLUMN_ID = "description";
+	private static final String DESCRIPTION_COLUMN_NAME = "Description";
 
 	private final TableViewer viewer;
 
@@ -96,12 +96,12 @@ public class FieldTableInspector {
 		viewer.getTable().setHeaderVisible(true);
 
 		List<IColumn> columns = new ArrayList<>();
-		columns.add(new ColumnBuilder(NAME_COLUNM_NAME, NAME_COLUNM_ID, nameLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(NAME_COLUMN_NAME, NAME_COLUMN_ID, nameLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(nameLabelProvider)).build());
-		columns.add(new ColumnBuilder(EXPRESSION_COLUNM_NAME, EXPRESSION_COLUNM_ID, expressionLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(EXPRESSION_COLUMN_NAME, EXPRESSION_COLUMN_ID, expressionLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(expressionLabelProvider)).build());
 		columns.add(
-				new ColumnBuilder(DESCRIPTION_COLUNM_NAME, DESCRIPTION_COLUNM_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
+				new ColumnBuilder(DESCRIPTION_COLUMN_NAME, DESCRIPTION_COLUMN_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
 						new OptimisticComparator(descriptionLabelProvider)).build());
 		ColumnManager.build(viewer, columns, null);
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
@@ -56,7 +56,12 @@ import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 public class ParameterTableInspector {
 
 	public static final String PARAMETER_TREE_NAME = "EventEditingWizardParameterPage.ParamtersTree"; //$NON-NLS-1$
-
+	private static final String INDEX_COLUNM_ID = "index";
+	private static final String INDEX_COLUNM_NAME = "Index";
+	private static final String NAME_COLUNM_ID = "name";
+	private static final String NAME_COLUNM_NAME = "Name";
+	private static final String DESCRIPTION_COLUNM_ID = "description";
+	private static final String DESCRIPTION_COLUNM_NAME = "Description";
 	private final TreeViewer viewer;
 
 	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
@@ -101,12 +106,13 @@ public class ParameterTableInspector {
 
 		tree.setData("name", PARAMETER_TREE_NAME); //$NON-NLS-1$
 		List<IColumn> columns = new ArrayList<>();
-		columns.add(new ColumnBuilder("Index", "index", indexLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(INDEX_COLUNM_NAME, INDEX_COLUNM_ID, indexLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(indexLabelProvider)).build());
-		columns.add(new ColumnBuilder("Name", "name", nameLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(NAME_COLUNM_NAME, NAME_COLUNM_ID, nameLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(nameLabelProvider)).build());
-		columns.add(new ColumnBuilder("Description", "description", descriptionLabelProvider).comparator(//$NON-NLS-1$
-				new OptimisticComparator(descriptionLabelProvider)).build());
+		columns.add(
+				new ColumnBuilder(DESCRIPTION_COLUNM_NAME, DESCRIPTION_COLUNM_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
+						new OptimisticComparator(descriptionLabelProvider)).build());
 		ColumnManager.build(viewer, columns, null);
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
@@ -52,8 +52,6 @@ import org.openjdk.jmc.ui.misc.OptimisticComparator;
 import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 
 public class ParameterTableInspector {
-
-	public static final String PARAMETER_TREE_NAME = "EventEditingWizardParameterPage.ParamtersTree"; //$NON-NLS-1$
 	private static final String INDEX_COLUNM_ID = "index";
 	private static final String INDEX_COLUNM_NAME = "Index";
 	private static final String NAME_COLUNM_ID = "name";

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
@@ -52,19 +52,20 @@ import org.openjdk.jmc.ui.misc.OptimisticComparator;
 import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 
 public class ParameterTableInspector {
-	private static final String INDEX_COLUNM_ID = "index";
-	private static final String INDEX_COLUNM_NAME = "Index";
-	private static final String NAME_COLUNM_ID = "name";
-	private static final String NAME_COLUNM_NAME = "Name";
-	private static final String DESCRIPTION_COLUNM_ID = "description";
-	private static final String DESCRIPTION_COLUNM_NAME = "Description";
+	private static final String RETURN_VALUE_INDEX_PLACEHOLDER = "ReturnValue";
+	private static final String INDEX_COLUMN_ID = "index";
+	private static final String INDEX_COLUMN_NAME = "Index";
+	private static final String NAME_COLUMN_ID = "name";
+	private static final String NAME_COLUMN_NAME = "Name";
+	private static final String DESCRIPTION_COLUMN_ID = "description";
+	private static final String DESCRIPTION_COLUMN_NAME = "Description";
 	private final TableViewer viewer;
 
 	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
 		@Override
 		public String getText(Object element) {
 			if (element instanceof ICapturedValue) {
-				return ((INamedCapturedValue) ((ICapturedValue) element)).getName();
+				return ((INamedCapturedValue) element).getName();
 			}
 			return element.toString();
 		}
@@ -74,9 +75,9 @@ public class ParameterTableInspector {
 		@Override
 		public String getText(Object element) {
 			if (element instanceof IMethodParameter) {
-				return (String.valueOf(((IMethodParameter) element).getIndex()));
+				return String.valueOf(((IMethodParameter) element).getIndex());
 			} else if (element instanceof IMethodReturnValue) {
-				return ("ReturnValue");
+				return RETURN_VALUE_INDEX_PLACEHOLDER;
 			}
 			return element.toString();
 		}
@@ -99,12 +100,12 @@ public class ParameterTableInspector {
 		viewer.getTable().setHeaderVisible(true);
 
 		List<IColumn> columns = new ArrayList<>();
-		columns.add(new ColumnBuilder(INDEX_COLUNM_NAME, INDEX_COLUNM_ID, indexLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(INDEX_COLUMN_NAME, INDEX_COLUMN_ID, indexLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(indexLabelProvider)).build());
-		columns.add(new ColumnBuilder(NAME_COLUNM_NAME, NAME_COLUNM_ID, nameLabelProvider).comparator( //$NON-NLS-1$
+		columns.add(new ColumnBuilder(NAME_COLUMN_NAME, NAME_COLUMN_ID, nameLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(nameLabelProvider)).build());
 		columns.add(
-				new ColumnBuilder(DESCRIPTION_COLUNM_NAME, DESCRIPTION_COLUNM_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
+				new ColumnBuilder(DESCRIPTION_COLUMN_NAME, DESCRIPTION_COLUMN_ID, descriptionLabelProvider).comparator(//$NON-NLS-1$
 						new OptimisticComparator(descriptionLabelProvider)).build());
 		ColumnManager.build(viewer, columns, null);
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.manager.wizards;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Tree;
+import org.openjdk.jmc.console.ext.agent.manager.model.ICapturedValue;
+import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
+import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
+import org.openjdk.jmc.console.ext.agent.manager.model.INamedCapturedValue;
+import org.openjdk.jmc.ui.column.ColumnBuilder;
+import org.openjdk.jmc.ui.column.ColumnManager;
+import org.openjdk.jmc.ui.column.IColumn;
+import org.openjdk.jmc.ui.misc.OptimisticComparator;
+import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
+
+public class ParameterTableInspector {
+
+	public static final String PARAMETER_TREE_NAME = "EventEditingWizardParameterPage.ParamtersTree"; //$NON-NLS-1$
+
+	private final TreeViewer viewer;
+
+	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof ICapturedValue) {
+				return ((INamedCapturedValue) ((ICapturedValue) element)).getName();
+			}
+			return element.toString();
+		}
+	};
+
+	private final ColumnLabelProvider indexLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof IMethodParameter) {
+				return (String.valueOf(((IMethodParameter) element).getIndex()));
+			} else if (element instanceof IMethodReturnValue) {
+				return ("ReturnValue");
+			}
+			return element.toString();
+		}
+	};
+
+	private final ColumnLabelProvider descriptionLabelProvider = new ColumnLabelProvider() {
+		@Override
+		public String getText(Object element) {
+			if (element instanceof ICapturedValue) {
+				return ((ICapturedValue) element).getDescription();
+			}
+			return element.toString();
+		}
+	};
+
+	public ParameterTableInspector(Composite parent) {
+		Tree tree = new Tree(parent,
+				SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
+		tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		viewer = new TreeViewer(tree);
+		viewer.setContentProvider(new TreeStructureContentProvider());
+		ColumnViewerToolTipSupport.enableFor(viewer);
+
+		tree.setData("name", PARAMETER_TREE_NAME); //$NON-NLS-1$
+		List<IColumn> columns = new ArrayList<>();
+		columns.add(new ColumnBuilder("Index", "index", indexLabelProvider).comparator( //$NON-NLS-1$
+				new OptimisticComparator(indexLabelProvider)).build());
+		columns.add(new ColumnBuilder("Name", "name", nameLabelProvider).comparator( //$NON-NLS-1$
+				new OptimisticComparator(nameLabelProvider)).build());
+		columns.add(new ColumnBuilder("Description", "description", descriptionLabelProvider).comparator(//$NON-NLS-1$
+				new OptimisticComparator(descriptionLabelProvider)).build());
+		ColumnManager.build(viewer, columns, null);
+	}
+
+	public void setInput(Object input) {
+		viewer.setInput(input);
+	}
+
+	public TreeViewer getViewer() {
+		return viewer;
+	}
+
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/ParameterTableInspector.java
@@ -37,12 +37,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
-import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
-import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Tree;
 import org.openjdk.jmc.console.ext.agent.manager.model.ICapturedValue;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
@@ -62,7 +60,7 @@ public class ParameterTableInspector {
 	private static final String NAME_COLUNM_NAME = "Name";
 	private static final String DESCRIPTION_COLUNM_ID = "description";
 	private static final String DESCRIPTION_COLUNM_NAME = "Description";
-	private final TreeViewer viewer;
+	private final TableViewer viewer;
 
 	private final ColumnLabelProvider nameLabelProvider = new ColumnLabelProvider() {
 		@Override
@@ -97,14 +95,11 @@ public class ParameterTableInspector {
 	};
 
 	public ParameterTableInspector(Composite parent) {
-		Tree tree = new Tree(parent,
-				SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
-		tree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		viewer = new TreeViewer(tree);
+		viewer = new TableViewer(parent, SWT.V_SCROLL | SWT.BORDER | SWT.FULL_SELECTION);
+		viewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		viewer.setContentProvider(new TreeStructureContentProvider());
-		ColumnViewerToolTipSupport.enableFor(viewer);
+		viewer.getTable().setHeaderVisible(true);
 
-		tree.setData("name", PARAMETER_TREE_NAME); //$NON-NLS-1$
 		List<IColumn> columns = new ArrayList<>();
 		columns.add(new ColumnBuilder(INDEX_COLUNM_NAME, INDEX_COLUNM_ID, indexLabelProvider).comparator( //$NON-NLS-1$
 				new OptimisticComparator(indexLabelProvider)).build());
@@ -120,7 +115,7 @@ public class ParameterTableInspector {
 		viewer.setInput(input);
 	}
 
-	public TreeViewer getViewer() {
+	public TableViewer getViewer() {
 		return viewer;
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
@@ -2,7 +2,7 @@ package org.openjdk.jmc.console.ext.agent.manager.wizards;
 
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
-import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -12,6 +12,9 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
 public class TableButtonControls extends Composite {
+	private static final String ADD_BTN_LABEL = "Add";
+	private static final String EDIT_BTN_LABEL = "Edit";
+	private static final String REMOVE_BTN_LABEL = "Remove";
 
 	private Button addBtn;
 	private Button editBtn;
@@ -19,9 +22,9 @@ public class TableButtonControls extends Composite {
 	private Runnable addBtnLister;
 	private Runnable removeBtnLister;
 	private Runnable editBtnLister;
-	private final TreeViewer viewer;
+	private final TableViewer viewer;
 
-	TableButtonControls(Composite parent, TreeViewer viewer) {
+	TableButtonControls(Composite parent, TableViewer viewer) {
 		super(parent, SWT.NONE);
 		this.viewer = viewer;
 
@@ -32,15 +35,15 @@ public class TableButtonControls extends Composite {
 
 		addBtn = new Button(this, SWT.PUSH);
 		addBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		addBtn.setText("Add");
+		addBtn.setText(ADD_BTN_LABEL);
 
 		removeBtn = new Button(this, SWT.PUSH);
 		removeBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		removeBtn.setText("Remove");
+		removeBtn.setText(REMOVE_BTN_LABEL);
 
 		editBtn = new Button(this, SWT.PUSH);
 		editBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		editBtn.setText("Edit");
+		editBtn.setText(EDIT_BTN_LABEL);
 
 		bindListeners();
 		updateButtonsAccordingTo(false);
@@ -66,7 +69,6 @@ public class TableButtonControls extends Composite {
 
 	private void bindListeners() {
 		addBtn.addListener(SWT.Selection, new Listener() {
-
 			@Override
 			public void handleEvent(Event e) {
 				if (addBtnLister != null) {
@@ -77,7 +79,6 @@ public class TableButtonControls extends Composite {
 		});
 
 		removeBtn.addListener(SWT.Selection, new Listener() {
-
 			@Override
 			public void handleEvent(Event e) {
 				if (removeBtnLister != null) {
@@ -87,7 +88,6 @@ public class TableButtonControls extends Composite {
 		});
 
 		editBtn.addListener(SWT.Selection, new Listener() {
-
 			@Override
 			public void handleEvent(Event e) {
 				if (editBtnLister != null) {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
@@ -13,9 +13,9 @@ import org.eclipse.swt.widgets.Listener;
 
 public class TableButtonControls extends Composite {
 
-	Button addBtn;
-	Button editBtn;
-	Button removeBtn;
+	private Button addBtn;
+	private Button editBtn;
+	private Button removeBtn;
 	private Runnable addBtnLister;
 	private Runnable removeBtnLister;
 	private Runnable editBtnLister;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
@@ -1,15 +1,11 @@
 package org.openjdk.jmc.console.ext.agent.manager.wizards;
 
-import org.eclipse.jface.viewers.ISelectionChangedListener;
-import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
 public class TableButtonControls extends Composite {
 	private static final String ADD_BTN_LABEL = "Add";
@@ -68,41 +64,10 @@ public class TableButtonControls extends Composite {
 	}
 
 	private void bindListeners() {
-		addBtn.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event e) {
-				if (addBtnLister != null) {
-					addBtnLister.run();
-				}
-			}
-
-		});
-
-		removeBtn.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event e) {
-				if (removeBtnLister != null) {
-					removeBtnLister.run();
-				}
-			}
-		});
-
-		editBtn.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event e) {
-				if (editBtnLister != null) {
-					editBtnLister.run();
-				}
-			}
-
-		});
-
-		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
-			@Override
-			public void selectionChanged(SelectionChangedEvent event) {
-				updateButtonsAccordingTo(!event.getSelection().isEmpty());
-			}
-		});
+		addBtn.addListener(SWT.Selection, e -> addBtnLister.run());
+		removeBtn.addListener(SWT.Selection, e -> removeBtnLister.run());
+		editBtn.addListener(SWT.Selection, e -> editBtnLister.run());
+		viewer.addSelectionChangedListener(e -> updateButtonsAccordingTo(!e.getSelection().isEmpty()));
 	}
 
 }

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/TableButtonControls.java
@@ -1,0 +1,108 @@
+package org.openjdk.jmc.console.ext.agent.manager.wizards;
+
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+public class TableButtonControls extends Composite {
+
+	Button addBtn;
+	Button editBtn;
+	Button removeBtn;
+	private Runnable addBtnLister;
+	private Runnable removeBtnLister;
+	private Runnable editBtnLister;
+	private final TreeViewer viewer;
+
+	TableButtonControls(Composite parent, TreeViewer viewer) {
+		super(parent, SWT.NONE);
+		this.viewer = viewer;
+
+		setLayout(new GridLayout());
+		GridData gd = new GridData(SWT.CENTER, SWT.TOP, false, false);
+		gd.widthHint = 150;
+		setLayoutData(gd);
+
+		addBtn = new Button(this, SWT.PUSH);
+		addBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		addBtn.setText("Add");
+
+		removeBtn = new Button(this, SWT.PUSH);
+		removeBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		removeBtn.setText("Remove");
+
+		editBtn = new Button(this, SWT.PUSH);
+		editBtn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		editBtn.setText("Edit");
+
+		bindListeners();
+		updateButtonsAccordingTo(false);
+
+	}
+
+	private void updateButtonsAccordingTo(boolean isSelection) {
+		removeBtn.setEnabled(isSelection);
+		editBtn.setEnabled(isSelection);
+	}
+
+	public void setAddButtonListener(Runnable addBtnListener) {
+		this.addBtnLister = addBtnListener;
+	}
+
+	public void setEditButtonListener(Runnable editBtnListener) {
+		this.editBtnLister = editBtnListener;
+	}
+
+	public void setRemoveButtonListener(Runnable removeBtnListener) {
+		this.removeBtnLister = removeBtnListener;
+	}
+
+	private void bindListeners() {
+		addBtn.addListener(SWT.Selection, new Listener() {
+
+			@Override
+			public void handleEvent(Event e) {
+				if (addBtnLister != null) {
+					addBtnLister.run();
+				}
+			}
+
+		});
+
+		removeBtn.addListener(SWT.Selection, new Listener() {
+
+			@Override
+			public void handleEvent(Event e) {
+				if (removeBtnLister != null) {
+					removeBtnLister.run();
+				}
+			}
+		});
+
+		editBtn.addListener(SWT.Selection, new Listener() {
+
+			@Override
+			public void handleEvent(Event e) {
+				if (editBtnLister != null) {
+					editBtnLister.run();
+				}
+			}
+
+		});
+
+		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+			@Override
+			public void selectionChanged(SelectionChangedEvent event) {
+				updateButtonsAccordingTo(!event.getSelection().isEmpty());
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
This PR implements the event editing part of probe editing wizard

The only thing to mention in that the EventMethodParameterEditingPage saves fields to the event when performFinish() is automatically called when exiting the wizard.  This is because it is not known if the Captured Value is a Parameter or Return Value until the wizard is closed. All other pages save values as they are modified, not all at once at the end.

Let me know what you think

See also: #60

Contribute to closing issue #31.