### PR TITLE
Adapt repository manager to singleton pattern

### DIFF
--- a/configuration/spotbugs/spotbugs-exclude.xml
+++ b/configuration/spotbugs/spotbugs-exclude.xml
@@ -106,4 +106,9 @@
 		<Method name="openFileDialog"/>
 		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
 	</Match>
+	<Match>
+		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
+		<Method name="createSingleton"/>
+		<Bug pattern="DC_DOUBLECHECK" />
+	</Match>
 </FindBugsFilter>

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/OpenPresetManagerHandler.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/OpenPresetManagerHandler.java
@@ -46,7 +46,7 @@ public class OpenPresetManagerHandler extends AbstractHandler {
 	@Override
 	public Object execute(ExecutionEvent event) {
 		Shell shell = Display.getCurrent().getActiveShell();
-		PresetRepository repository = PresetRepositoryFactory.create();
+		PresetRepository repository = PresetRepositoryFactory.createSingleton();
 
 		Dialog dialog = PresetManager.createFor(shell, repository);
 		dialog.open();

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
@@ -49,10 +49,14 @@ public class PresetRepositoryFactory {
 
 	public static PresetRepository createSingleton() {
 		if (singleton == null) {
-			singleton = create();
+			synchronized (PresetRepositoryFactory.class) {
+				if (singleton == null) {
+					singleton = create();
+				}
+			}
 		}
 
-		return create();
+		return singleton;
 	}
 
 	protected static PresetRepository create() {

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
@@ -45,7 +45,17 @@ public class PresetRepositoryFactory {
 	private static final File PRESET_STORAGE_DIR = AgentPlugin.getDefault().getStateLocation().append(".presets") // $NON-NLS-1$
 			.toFile();
 
-	public static PresetRepository create() {
+	private static PresetRepository singleton;
+
+	public static PresetRepository createSingleton() {
+		if (singleton == null) {
+			singleton = create();
+		}
+
+		return create();
+	}
+
+	protected static PresetRepository create() {
 		PresetRepository repository = new PresetRepository();
 		initiate(repository);
 		return repository;


### PR DESCRIPTION
This is a follow-up of #70 adapting repository manager to singleton pattern.

Use `PresetRepositoryFactory.createSingleton()` to obtain an instance.