### PR TITLE
copy local spotbugs-exclude contents to jmc in diff.patch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Build JMC
         run: ./scripts/buildjmc.sh
       - name: Check formatting

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ bin/
 
 # Ignore settings changes by the IDE
 .settings/
+.idea
+*.iml
 
 # Ignore test recordings
 application/tests/org.openjdk.jmc.rjmx.services.jfr.test/recording.jfr

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ cp -r jmc-agent-plugin/org.openjdk.jmc* jmc/application
 Apply the patch to JMC's root directory:
 ```sh
 $ cd jmc
-$ patch -p0 < ../jmc-agent-plugin/scripts/diff.patch
+$ git apply ../jmc-agent-plugin/scripts/diff.patch
 ``` 
 
 Get third party dependencies into a local p2 repo and make it available on localhost:

--- a/configuration/spotbugs/spotbugs-exclude.xml
+++ b/configuration/spotbugs/spotbugs-exclude.xml
@@ -48,6 +48,11 @@
 		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 	</Match>
 	<Match>
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi"/>
+		<Method name="refresh"/>
+		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+	</Match>
+	<Match>
 		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentFormPage"/>
 		<Bug pattern="UWF_UNWRITTEN_FIELD"/>
 	</Match>

--- a/scripts/buildrelease.sh
+++ b/scripts/buildrelease.sh
@@ -10,7 +10,7 @@ cp -r org.openjdk.jmc* jmc/application
 
 echo "======== Applying patch ================================="
 cd jmc
-patch -p0 < ../scripts/diff.patch
+git apply ../scripts/diff.patch
 cd ..
 
 echo "======== Building p2 repo ==============================="

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -1,51 +1,7 @@
-Index: application/org.openjdk.jmc.feature.rcp/feature.xml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
---- application/org.openjdk.jmc.feature.rcp/feature.xml	(revision 22758a7be462468c4dcd3f150b49363d739e6716)
-+++ application/org.openjdk.jmc.feature.rcp/feature.xml	(date 1597332118886)
-@@ -71,6 +71,10 @@
-          id="org.openjdk.jmc.feature.joverflow"
-          version="0.0.0"/>
- 
-+   <includes
-+         id="org.openjdk.jmc.feature.console.ext.agent"
-+         version="0.0.0"/>
-+
-    <requires>
-       <import feature="org.eclipse.rcp" version="3.8.0" match="greaterOrEqual"/>
-       <import feature="org.eclipse.help" version="1.4.0" match="greaterOrEqual"/>
-Index: application/pom.xml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
---- application/pom.xml	(revision 22758a7be462468c4dcd3f150b49363d739e6716)
-+++ application/pom.xml	(date 1597332154207)
-@@ -82,6 +82,7 @@
- 		<module>org.openjdk.jmc.feature.rcp</module>
- 		<module>org.openjdk.jmc.feature.rcp.update</module>
- 		<module>org.openjdk.jmc.feature.twitter</module>
-+		<module>org.openjdk.jmc.feature.console.ext.agent</module>
- 		<module>org.openjdk.jmc.flightrecorder.configuration</module>
- 		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui</module>
- 		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration</module>
-@@ -113,6 +114,7 @@
- 		<module>org.openjdk.jmc.ui.common</module>
- 		<module>org.openjdk.jmc.updatesite.ide</module>
- 		<module>org.openjdk.jmc.updatesite.rcp</module>
-+		<module>org.openjdk.jmc.console.ext.agent</module>
- 		<module>l10n</module>
- 		<module>tests</module>
- 		<module>coverage</module>
-Index: application/org.openjdk.jmc.console.ext.agent/pom.xml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
---- application/org.openjdk.jmc.console.ext.agent/pom.xml	(revision 8ae7fbeb4ee7b0b8d0cd7e285f2d042826075d2d)
-+++ application/org.openjdk.jmc.console.ext.agent/pom.xml	(date 1597332482734)
+diff --git a/application/org.openjdk.jmc.console.ext.agent/pom.xml b/application/org.openjdk.jmc.console.ext.agent/pom.xml
+index 4f39161a..8d4f7d8a 100644
+--- a/application/org.openjdk.jmc.console.ext.agent/pom.xml
++++ b/application/org.openjdk.jmc.console.ext.agent/pom.xml
 @@ -39,9 +39,7 @@
  
  	<parent>
@@ -71,13 +27,10 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
  	</properties>
  
  	<build>
-Index: application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
---- application/org.openjdk.jmc.feature.console.ext.agent/pom.xml	(revision 8ae7fbeb4ee7b0b8d0cd7e285f2d042826075d2d)
-+++ application/org.openjdk.jmc.feature.console.ext.agent/pom.xml	(date 1597332465702)
+diff --git a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
+index bb080eb8..1a74fd51 100644
+--- a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
++++ b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 @@ -37,9 +37,7 @@
  
  	<parent>
@@ -99,3 +52,137 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 +		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
  	</properties>
  </project>
+diff --git a/application/org.openjdk.jmc.feature.rcp/feature.xml b/application/org.openjdk.jmc.feature.rcp/feature.xml
+index af0c2f2f..a7af3c8a 100644
+--- a/application/org.openjdk.jmc.feature.rcp/feature.xml
++++ b/application/org.openjdk.jmc.feature.rcp/feature.xml
+@@ -71,6 +71,10 @@
+          id="org.openjdk.jmc.feature.joverflow"
+          version="0.0.0"/>
+ 
++   <includes
++         id="org.openjdk.jmc.feature.console.ext.agent"
++         version="0.0.0"/>
++
+    <requires>
+       <import feature="org.eclipse.rcp" version="3.8.0" match="greaterOrEqual"/>
+       <import feature="org.eclipse.help" version="1.4.0" match="greaterOrEqual"/>
+diff --git a/application/pom.xml b/application/pom.xml
+index bccc1036..0d89116b 100644
+--- a/application/pom.xml
++++ b/application/pom.xml
+@@ -81,7 +81,8 @@
+ 		<module>org.openjdk.jmc.feature.pde</module>
+ 		<module>org.openjdk.jmc.feature.rcp</module>
+ 		<module>org.openjdk.jmc.feature.rcp.update</module>
+-		<module>org.openjdk.jmc.feature.twitter</module>
++        <module>org.openjdk.jmc.feature.twitter</module>
++        <module>org.openjdk.jmc.feature.console.ext.agent</module>
+ 		<module>org.openjdk.jmc.flightrecorder.configuration</module>
+ 		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui</module>
+ 		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration</module>
+@@ -113,7 +114,8 @@
+ 		<module>org.openjdk.jmc.ui</module>
+ 		<module>org.openjdk.jmc.ui.common</module>
+ 		<module>org.openjdk.jmc.updatesite.ide</module>
+-		<module>org.openjdk.jmc.updatesite.rcp</module>
++        <module>org.openjdk.jmc.updatesite.rcp</module>
++        <module>org.openjdk.jmc.console.ext.agent</module>
+ 		<module>l10n</module>
+ 		<module>tests</module>
+ 		<module>coverage</module>
+diff --git a/configuration/spotbugs/spotbugs-exclude.xml b/configuration/spotbugs/spotbugs-exclude.xml
+index 97a251c4..be74fbca 100644
+--- a/configuration/spotbugs/spotbugs-exclude.xml
++++ b/configuration/spotbugs/spotbugs-exclude.xml
+@@ -32,6 +32,90 @@
+    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ -->
+ <FindBugsFilter>
++    <!-- copied from jmc-agent-plugin -->
++    <Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.AgentJmxHelper"/>
++		<Method name="retrieveCurrentTransforms"/>
++		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor"/>
++		<Method name="doAddPages"/>
++		<Bug pattern="REC_CATCH_EXCEPTION"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi"/>
++		<Method name="refresh"/>
++		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentFormPage"/>
++		<Bug pattern="UWF_UNWRITTEN_FIELD"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDocumentProvider"/>
++		<Method name="doSaveDocument"/>
++		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDocumentProvider"/>
++		<Method name="doSaveDocument"/>
++		<Bug pattern="DM_DEFAULT_ENCODING"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.presets.EditAgentSection" />
++		<Bug pattern="DM_DEFAULT_ENCODING"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.liveconfig.EventTableInspector"/>
++		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab"/>
++		<Method name="loadAgentListener"/>
++		<Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab"/>
++		<Bug pattern="URF_UNREAD_FIELD"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab"/>
++		<Bug pattern="UUF_UNUSED_FIELD"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.NonRuleBasedDamagerRepairer"/>
++		<Method name="endOfLineOf"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.NonRuleBasedDamagerRepairer"/>
++		<Method name="getDamageRegion"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDoubleClickStrategy"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab"/>
++		<Method name="loadAgentListener"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage" />
++		<Method name="openFileDialog"/>
++		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
++		<Method name="createSingleton"/>
++		<Bug pattern="DC_DOUBLECHECK" />
++	</Match>
+     <!-- Skip I18n -->
+     <Match>
+         <Bug pattern="DM_DEFAULT_ENCODING"/>


### PR DESCRIPTION
This PR updates the local `spotbugs-exclude.xml` and adds it's contents to the diff patch that gets applied to the main jmc repo. This ensures that the appropriate exclude filters are applied when building/testing jmc. This approach was mentioned in a review comment: https://github.com/rh-jmc-team/jmc-agent-plugin/pull/78#pullrequestreview-543276766

Additionally, there are a couple of other tweaks that are required.

The first being an update to the `validate.yml` in the github workflows to use jdk 11, now that it is required for jmc.

I also find it a lot easier to work with git diffs, especially if/when the `diff.patch` needs to be updated. There are a couple of instances where `> patch [..]` gets replaced with `git apply [..]`.

Lastly, while Eclipse is certainly better for launching and testing the changes made to the plugin while developing, I think I've had enough of the IDE for now and am trying out a combo of VS Code and Intellij for this work .. so I've added some Intellij-specific stuff to the `.gitignore` under the IDE settings portion. 
