### PR TITLE
change name of "Finish" button in Start Agent Wizard to "Start"

### DIFF
--- a/configuration/spotbugs/spotbugs-exclude.xml
+++ b/configuration/spotbugs/spotbugs-exclude.xml
@@ -95,10 +95,10 @@
 	</Match>
 	<!-- This is a false positive. Eclipse handles initialization of critical components elsewhere -->
     <Match>
-    	<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
-    	<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
+		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
     </Match>
-    	<Match>
+    <Match>
 		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.NonRuleBasedDamagerRepairer"/>
 		<Method name="endOfLineOf"/>
 		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
@@ -124,15 +124,18 @@
     <!-- There is a blanket exclude on these types of bugs in JMC.
      in UI classes the memory overhead is minimal and reworking it isn't really worth it -->
     <Match>
-    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
-    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
+		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
     </Match>
     <Match>
-    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
-    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
+		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
     </Match>
     <Match>
-    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
-    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
+		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
+    <Match>
+		<Class name="org.openjdk.jmc.console.ext.agent.actions.AgentEditorOpener$ConnectJob" />
     </Match>
 </FindBugsFilter>

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
@@ -37,7 +37,11 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -111,8 +115,20 @@ public class AgentEditorOpener implements IActionFactory {
 
 			// local JVM but agent not running
 			if (!helper.isMXBeanRegistered() && helper.isLocalJvm()) {
-				DisplayToolkit.safeAsyncExec(Display.getDefault(),
-						() -> DialogToolkit.openWizardWithHelp(new StartAgentWizard(helper)));
+				DisplayToolkit.safeAsyncExec(Display.getDefault(), () -> {
+					WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(),
+							new StartAgentWizard(helper)) {
+						@Override
+						public void createButtonsForButtonBar(Composite parent) {
+							super.createButtonsForButtonBar(parent);
+							Button finishButton = getButton(IDialogConstants.FINISH_ID);
+							finishButton.setText(StartAgentWizard.WIZARD_FINISH_BUTTON_TEXT);
+						}
+					};
+					dialog.setHelpAvailable(true);
+					dialog.create();
+					dialog.open();
+				});
 				return Status.OK_STATUS;
 			}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
@@ -122,7 +122,7 @@ public class AgentEditorOpener implements IActionFactory {
 						public void createButtonsForButtonBar(Composite parent) {
 							super.createButtonsForButtonBar(parent);
 							Button finishButton = getButton(IDialogConstants.FINISH_ID);
-							finishButton.setText(StartAgentWizard.WIZARD_FINISH_BUTTON_TEXT);
+							finishButton.setText(Messages.StartAgentWizard_WIZARD_FINISH_BUTTON_TEXT);
 						}
 					};
 					dialog.setHelpAvailable(true);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
@@ -179,6 +179,7 @@ public class Messages extends NLS {
 	public static String StartAgentWizard_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED;
 	public static String StartAgentWizard_MESSAGE_INVALID_AGENT_CONFIG;
 	public static String StartAgentWizard_MESSAGE_ACCESS_TO_UNSAFE_REQUIRED;
+	public static String StartAgentWizard_WIZARD_FINISH_BUTTON_TEXT;
 	public static String StartAgentWizardPage_PAGE_NAME;
 	public static String StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_TITLE;
 	public static String StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION;

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
@@ -184,7 +184,7 @@ StartAgentWizard_MESSAGE_INVALID_AGENT_CONFIG=An invalid configuration is entere
 StartAgentWizard_MESSAGE_ACCESS_TO_UNSAFE_REQUIRED=Could not access jdk.internal.misc.Unsafe! Did you run your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'?
 StartAgentWizardPage_PAGE_NAME=Start Agent Wizard Page
 StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_TITLE=Start JMC Agent
-StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION=Enter the JMC Agent configuration details and then click Finish to start the agent.
+StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION=Enter the JMC Agent configuration details and then click 'Start' to start the agent.
 StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_JAR=Path to an agent JAR
 StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_CONFIG=(Optional) Path to an agent configuration
 StartAgentWizardPage_LABEL_TARGET_JVM=Target JVM: 

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
@@ -37,8 +37,8 @@ AgentEditorOpener_MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED=Starting an
 AgentEditorOpener_MESSAGE_START_AGENT_MANUALLY=Start the agent manually and try again
 AgentEditorOpener_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR=Failed to open the JMC Agent Editor
 
-AgendEditor_CONNECTION_LOST=Connection Lost
-AgendEditor_AGENT_EDITOR_TITLE=Agent Live Config
+AgentEditor_CONNECTION_LOST=Connection Lost
+AgentEditor_AGENT_EDITOR_TITLE=Agent Live Config
 
 CapturedValue_ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX=Relation key has incorrect syntax.
 CapturedValue_ERROR_CONVERTER_HAS_INCORRECT_SYNTAX=Converter has incorrect syntax.
@@ -193,3 +193,4 @@ StartAgentWizardPage_LABEL_AGENT_XML=Agent XML:
 StartAgentWizardPage_LABEL_BROWSE=Browse...
 StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_JAR=Browser for JMC Agent JAR
 StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_CONFIG=Browser for JMC Agent Configuration
+StartAgentWizard_WIZARD_FINISH_BUTTON_TEXT=Start

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -92,15 +92,15 @@ index a2d52be..4d0015e 100644
  		<module>tests</module>
  		<module>coverage</module>
 diff --git a/configuration/spotbugs/spotbugs-exclude.xml b/configuration/spotbugs/spotbugs-exclude.xml
-index 97a251c..bc50f52 100644
+index 97a251c4..9ab4df29 100644
 --- a/configuration/spotbugs/spotbugs-exclude.xml
 +++ b/configuration/spotbugs/spotbugs-exclude.xml
-@@ -32,6 +32,109 @@
+@@ -32,6 +32,112 @@
     WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  -->
  <FindBugsFilter>
-+	<!-- copied from jmc-agent-plugin -->
-+	<Match>
++    <!-- copied from jmc-agent-plugin -->
++    <Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.AgentJmxHelper"/>
 +		<Method name="retrieveCurrentTransforms"/>
 +		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
@@ -161,11 +161,11 @@ index 97a251c..bc50f52 100644
 +		<Bug pattern="DC_DOUBLECHECK" />
 +	</Match>
 +	<!-- This is a false positive. Eclipse handles initialization of critical components elsewhere -->
-+    	<Match>
-+    		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
-+    		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
-+   	</Match>
-+    	<Match>
++    <Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
++    </Match>
++    <Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.NonRuleBasedDamagerRepairer"/>
 +		<Method name="endOfLineOf"/>
 +		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
@@ -191,24 +191,20 @@ index 97a251c..bc50f52 100644
 +    <!-- There is a blanket exclude on these types of bugs in JMC.
 +     in UI classes the memory overhead is minimal and reworking it isn't really worth it -->
 +    <Match>
-+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
-+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
++		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
 +    </Match>
 +    <Match>
-+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
-+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
++		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
 +    </Match>
 +    <Match>
-+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
-+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
++		<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
++    </Match>
++    <Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.actions.AgentEditorOpener$ConnectJob" />
 +    </Match>
      <!-- Skip I18n -->
      <Match>
          <Bug pattern="DM_DEFAULT_ENCODING"/>
-@@ -1138,4 +1241,4 @@
- 		<Class name="org.openjdk.jmc.rjmx.subscription.internal.EvilMethodsClass"/>
- 	</Match>
- 		
--</FindBugsFilter>
-\ No newline at end of file
-+</FindBugsFilter>


### PR DESCRIPTION
This PR addresses issue https://github.com/rh-jmc-team/jmc-agent-plugin/issues/43, in which it would be nice from a UX perspective to have the "Finish" button in the Start Agent Wizard to say "Start" instead.

This approach was taken from a StackOverflow discussion (https://stackoverflow.com/a/23492732), where the text of the button can be changed by overriding `createButtonsForButtonBar()` in the `WizardDialog`, finding the "Finish" button, and replacing the text.

Screenshot:
![2020-12-04-115641_691x382_scrot](https://user-images.githubusercontent.com/10425301/101193220-43dcc400-362a-11eb-9b05-670265f8c314.png)
