### PR TITLE
add basic file validation when opening a xml file in the presets tab

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 
 import javax.xml.transform.stream.StreamSource;
 
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
@@ -30,6 +31,7 @@ import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlEditor;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ProbeValidator;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ValidationResult;
 import org.openjdk.jmc.ui.MCPathEditorInput;
+import org.openjdk.jmc.ui.misc.DialogToolkit;
 import org.xml.sax.SAXException;
 
 public class EditAgentSection extends Composite {
@@ -40,6 +42,8 @@ public class EditAgentSection extends Composite {
 	private static final String MESSAGE_VALIDATE = "Validate";
 	private static final String MESSAGE_APPLY = "Apply";
 	private static final String MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND = "No errors/warnings found!";
+	private static final String MESSAGE_ERROR_OPENING_TITLE = "Problem opening the XML file";
+	private static final String MESSAGE_FILE_NOT_FOUND = "The XML file to open does not exist: {0}";
 
 	private AgentJmxHelper agentJmxHelper = null;
 	final private Text messageOutput;
@@ -83,7 +87,13 @@ public class EditAgentSection extends Composite {
 			edit.setText(MESSAGE_EDIT);
 			edit.setLayoutData(gridData);
 			edit.addListener(SWT.Selection, event -> {
-				IEditorInput input = new MCPathEditorInput(new File(text.getText()), false);
+				File file = new File(text.getText());
+				if (!file.exists()) {
+					DialogToolkit.showErrorDialogAsync(Display.getDefault(), MESSAGE_ERROR_OPENING_TITLE,
+							NLS.bind(MESSAGE_FILE_NOT_FOUND, text.getText()));
+					return;
+				}
+				IEditorInput input = new MCPathEditorInput(file, false);
 				input = XmlEditor.convertInput(input);
 				try {
 					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().openEditor(input,


### PR DESCRIPTION
This PR addresses issue https://github.com/rh-jmc-team/jmc-agent-plugin/issues/30, in which trying to open a file with an empty or invalid path would open a new editor with the error message "can't find IDfind.ext".

The approach here is to perform basic file validation, to check if the file exists. If not, a dialog is shown letting the user know that the path supplied is not valid.

Screenshot:
![2020-12-04-131328_630x282_scrot](https://user-images.githubusercontent.com/10425301/101199512-fca70100-3632-11eb-970f-0070c7a0842d.png)

