### PR TITLE
add FIND_EXT groupMarker to the menu manager

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
@@ -36,6 +36,9 @@ package org.openjdk.jmc.console.ext.agent.editor;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jface.action.GroupMarker;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.layout.FillLayout;
@@ -44,12 +47,15 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
+import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.IMessageManager;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.eclipse.ui.internal.WorkbenchWindow;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
@@ -70,6 +76,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
+//TODO: remove the @SuppressWarnings once IWorkbenchActionConstants.FIND_EXT is added to ApplicationActionBarAdvisor in JMC
 public class AgentEditor extends FormEditor implements IConnectionListener {
 
 	public static final String EDITOR_ID = "org.openjdk.jmc.console.ext.agent.editor.AgentEditor"; //$NON-NLS-1$
@@ -109,6 +116,20 @@ public class AgentEditor extends FormEditor implements IConnectionListener {
 		setUpInjectables();
 
 		getEditorInput().getAgentJmxHelper().addConnectionChangedListener(this);
+
+		// TODO: move the addition of this ContributionItem to ApplicationActionBarAdvisor in JMC when integrating to main repository
+		((WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow()).getMenuBarManager().getItems();
+		for (IContributionItem m : ((WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow())
+				.getMenuBarManager().getItems()) {
+			if (m.getId() == IWorkbenchActionConstants.M_EDIT) {
+				MenuManager mm = ((MenuManager) m);
+				if (mm.indexOf(IWorkbenchActionConstants.FIND_EXT) == -1) {
+					mm.add(new GroupMarker(IWorkbenchActionConstants.FIND_EXT));
+					mm.update(true);
+					break;
+				}
+			}
+		}
 	}
 
 	@Override

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentFormPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentFormPage.java
@@ -35,17 +35,24 @@ package org.openjdk.jmc.console.ext.agent.editor;
 import javax.inject.Inject;
 
 import org.eclipse.jface.action.GroupMarker;
+import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbenchActionConstants;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.widgets.Form;
+import org.eclipse.ui.internal.WorkbenchWindow;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 /**
  * Extension point class that agent console tabs can subclass. The ConsoleTab uses the FormPage .
  */
+//TODO: remove the @SuppressWarnings once IWorkbenchActionConstants.FIND_EXT is added to ApplicationActionBarAdvisor in JMC
+@SuppressWarnings("restriction")
 public class AgentFormPage extends FormPage /* implements IConsolePageContainer */ {
 
 	private String id;
@@ -87,6 +94,21 @@ public class AgentFormPage extends FormPage /* implements IConsolePageContainer 
 		IToolBarManager toolBar = managedForm.getForm().getToolBarManager();
 		toolBar.add(new GroupMarker("first"));
 		toolBar.update(true);
+
+		// TODO: move the addition of this ContributionItem to ApplicationActionBarAdvisor in JMC when integrating to main repository
+		((WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow()).getMenuBarManager().getItems();
+		for (IContributionItem m : ((WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow())
+				.getMenuBarManager().getItems()) {
+			if (m.getId() == IWorkbenchActionConstants.M_EDIT) {
+				MenuManager mm = ((MenuManager) m);
+				if (mm.indexOf(IWorkbenchActionConstants.FIND_EXT) == -1) {
+					mm.add(new GroupMarker(IWorkbenchActionConstants.FIND_EXT));
+					mm.update(true);
+					break;
+				}
+			}
+		}
+
 	}
 
 	protected void validateDependencies() {


### PR DESCRIPTION
This PR addresses issue https://github.com/rh-jmc-team/jmc-agent-plugin/issues/42, in which an exception is is thrown the first time an editor is opened.

The solution here is a stopgap measure until this plugin is integrated into JMC itself, as the more "proper" solution would be to add the missing groupMarker to `ApplicationActionBarAdvisor` in JMC. Nevertheless, this fix will work for the current use case.

I found similar issues to this in [[0]](https://issues.apache.org/jira/browse/DIRSTUDIO-1018) [[1]](https://openchrom.wordpress.com/2013/05/14/cant-find-idfind-ext-exception/) [[2]](https://bugs.eclipse.org/bugs/show_bug.cgi?id=528530), with a bit more of an explanation in a [stackoverflow post [2]](https://stackoverflow.com/a/14266688).

References:
[0] https://issues.apache.org/jira/browse/DIRSTUDIO-1018
[1] https://openchrom.wordpress.com/2013/05/14/cant-find-idfind-ext-exception/
[2] https://bugs.eclipse.org/bugs/show_bug.cgi?id=528530
[3] https://stackoverflow.com/a/14266688