### PR TITLE
externalize message strings

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
@@ -52,11 +52,11 @@ import java.util.Set;
 import java.util.logging.Level;
 
 public final class AgentJmxHelper {
-	private final static String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController";
-	private final static String DEFINE_EVENT_PROBES = "defineEventProbes";
-	private final static String RETRIEVE_EVENT_PROBES = "retrieveEventProbes";
-	private final static String RETRIEVE_CURRENT_TRANSFORMS = "retrieveCurrentTransforms";
-	private final static String CONNECTION_USAGE = "Agent MBean";
+	private final static String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
+	private final static String DEFINE_EVENT_PROBES = "defineEventProbes"; //$NON-NLS-1$
+	private final static String RETRIEVE_EVENT_PROBES = "retrieveEventProbes"; //$NON-NLS-1$
+	private final static String RETRIEVE_CURRENT_TRANSFORMS = "retrieveCurrentTransforms"; //$NON-NLS-1$
+	private final static String CONNECTION_USAGE = "Agent MBean"; //$NON-NLS-1$
 
 	private final IServerHandle serverHandle;
 	private final IConnectionHandle connectionHandle;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentPlugin.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentPlugin.java
@@ -40,7 +40,7 @@ import org.osgi.framework.BundleContext;
 public class AgentPlugin extends MCAbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.openjdk.jmc.console.ext.agent"; //$NON-NLS-1$
 
-	public static final String ICON_AGENT = "agent-16.png";
+	public static final String ICON_AGENT = "agent-16.png"; //$NON-NLS-1$
 
 	private static AgentPlugin m_plugin;
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditorInput;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.StartAgentWizard;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
@@ -64,11 +65,6 @@ import java.util.Objects;
 // TODO: Export IActionFactory to this plug-in and remove @SuppressWarnings once it's official in JMC   
 @SuppressWarnings("restriction")
 public class AgentEditorOpener implements IActionFactory {
-	private final static String JOB_NAME = "Connecting to RJMX service";
-	private final static String MESSAGE_COULD_NOT_CONNECT = "Could not connect";
-	private final static String MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED = "Starting an agent on remote JVM is not supported";
-	private final static String MESSAGE_START_AGENT_MANUALLY = "Start the agent manually and try again";
-	private final static String MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR = "Failed to open the JMC Agent Editor";
 
 	@Override
 	public Executable createAction(IServerHandle serverHandle) {
@@ -82,7 +78,7 @@ public class AgentEditorOpener implements IActionFactory {
 		private AgentJmxHelper helper;
 
 		private ConnectJob(IServerHandle serverHandle) {
-			super(JOB_NAME);
+			super(Messages.AgentEditorOpener_JOB_NAME);
 
 			this.serverHandle = Objects.requireNonNull(serverHandle);
 		}
@@ -101,8 +97,8 @@ public class AgentEditorOpener implements IActionFactory {
 			} catch (ConnectionException e) {
 				// FIXME: Show stacktrace? (Need to show our own ExceptionDialog in that case, or maybe create our own DetailsAreaProvider, see WorkbenchStatusDialogManager.setDetailsAreaProvider)
 				return new Status(IStatus.ERROR, AgentPlugin.PLUGIN_ID, IStatus.ERROR,
-						NLS.bind(MESSAGE_COULD_NOT_CONNECT, serverHandle.getServerDescriptor().getDisplayName(),
-								e.getMessage()),
+						NLS.bind(Messages.AgentEditorOpener_MESSAGE_COULD_NOT_CONNECT,
+								serverHandle.getServerDescriptor().getDisplayName(), e.getMessage()),
 						e);
 			}
 		}
@@ -124,8 +120,9 @@ public class AgentEditorOpener implements IActionFactory {
 			if (!helper.isMXBeanRegistered() && !helper.isLocalJvm()) {
 				DisplayToolkit.safeAsyncExec(Display.getDefault(), () -> {
 					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-					DialogToolkit.showError(window.getShell(), MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED,
-							MESSAGE_START_AGENT_MANUALLY);
+					DialogToolkit.showError(window.getShell(),
+							Messages.AgentEditorOpener_MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED,
+							Messages.AgentEditorOpener_MESSAGE_START_AGENT_MANUALLY);
 				});
 				return Status.OK_STATUS;
 			}
@@ -137,7 +134,8 @@ public class AgentEditorOpener implements IActionFactory {
 					IEditorInput ei = new AgentEditorInput(serverHandle, helper.getConnectionHandle(), helper);
 					window.getActivePage().openEditor(ei, AgentEditor.EDITOR_ID, true);
 				} catch (PartInitException e) {
-					DialogToolkit.showException(window.getShell(), MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR, e);
+					DialogToolkit.showException(window.getShell(),
+							Messages.AgentEditorOpener_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR, e);
 				}
 			});
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
@@ -53,6 +53,7 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.EditorTab;
 import org.openjdk.jmc.console.ext.agent.tabs.liveconfig.LiveConfigTab;
 import org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab;
@@ -74,9 +75,6 @@ public class AgentEditor extends FormEditor implements IConnectionListener {
 
 	public static final String EDITOR_ID = "org.openjdk.jmc.console.ext.agent.editor.AgentEditor"; //$NON-NLS-1$
 
-	private static final String CONNECTION_LOST = "Connection Lost";
-	private static final String COULD_NOT_CONNECT = "Could not connect";
-
 	private volatile IConnectionHandle connection;
 
 	private StackLayout stackLayout;
@@ -92,7 +90,7 @@ public class AgentEditor extends FormEditor implements IConnectionListener {
 					for (Object page : pages) {
 						if (page instanceof IFormPage) {
 							IMessageManager mm = ((IFormPage) page).getManagedForm().getMessageManager();
-							mm.addMessage(this, CONNECTION_LOST, null, IMessageProvider.ERROR);
+							mm.addMessage(this, Messages.AgentEditor_CONNECTION_LOST, null, IMessageProvider.ERROR);
 						}
 					}
 				}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/CapturedValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/CapturedValue.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -46,9 +47,6 @@ class CapturedValue implements ICapturedValue {
 	private static final String DEFAULT_STRING_FIELD = ""; // $NON-NLS-1$
 	private static final Object DEFAULT_OBJECT_TYPE = null;
 	private static final String CONVERTER_REGEX = "([a-zA-Z_$][a-zA-Z0-9_$]*\\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)"; // $NON-NLS-1$
-
-	private static final String ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX = "Relation key has incorrect syntax.";
-	private static final String ERROR_CONVERTER_HAS_INCORRECT_SYNTAX = "Converter has incorrect syntax.";
 
 	private static final String XML_TAG_CAPTURED_VALUE = "capturedvalue"; // $NON-NLS-1$
 	private static final String XML_TAG_NAME = "name"; // $NON-NLS-1$
@@ -180,7 +178,7 @@ class CapturedValue implements ICapturedValue {
 			try {
 				new URI(relationKey);
 			} catch (URISyntaxException e) {
-				throw new IllegalArgumentException(ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX);
+				throw new IllegalArgumentException(Messages.CapturedValue_ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX);
 			}
 		}
 
@@ -197,7 +195,7 @@ class CapturedValue implements ICapturedValue {
 		if (converter != null && !converter.isEmpty()) {
 			converter = converter.trim();
 			if (!converter.matches(CONVERTER_REGEX)) {
-				throw new IllegalArgumentException(ERROR_CONVERTER_HAS_INCORRECT_SYNTAX);
+				throw new IllegalArgumentException(Messages.CapturedValue_ERROR_CONVERTER_HAS_INCORRECT_SYNTAX);
 			}
 		}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -59,19 +60,6 @@ public class Event implements IEvent {
 	private static final String PATH_REGEX = "([^/]+/)*([^/]*)"; // $NON-NLS-1$
 	private static final String METHOD_NAME_REGEX = "[a-zA-Z_$][a-zA-Z0-9_$]*"; // $NON-NLS-1$
 	private static final String METHOD_DESCRIPTOR_REGEX = "\\((\\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))*\\)(V|\\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))"; // $NON-NLS-1$
-
-	private static final String ERROR_ID_CANNOT_BE_EMPTY_OR_NULL = "ID cannot be empty or null.";
-	private static final String ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL = "Name cannot be empty or null.";
-	private static final String ERROR_CLASS_CANNOT_BE_EMPTY_OR_NULL = "Class cannot be empty or null.";
-	private static final String ERROR_METHOD_NAME_CANNOT_BE_EMPTY_OR_NULL = "Method name cannot be empty or null.";
-	private static final String ERROR_METHOD_DESCRIPTOR_CANNOT_BE_EMPTY_OR_NULL = "Method descriptor cannot be empty or null.";
-	private static final String ERROR_METHOD_PARAMETER_CANNOT_BE_NULL = "Method parameter cannot be null.";
-	private static final String ERROR_FIELD_CANNOT_BE_NULL = "Field cannot be null.";
-	private static final String ERROR_CLASS_HAS_INCORRECT_SYNTAX = "Class has incorrect syntax.";
-	private static final String ERROR_PATH_HAS_INCORRECT_SYNTAX = "Path has incorrect syntax.";
-	private static final String ERROR_METHOD_NAME_HAS_INCORRECT_SYNTAX = "Method name has incorrect syntax.";
-	private static final String ERROR_METHOD_DESCRIPTOR_HAS_INCORRECT_SYNTAX = "Method descriptor has incorrect syntax.";
-	private static final String ERROR_INDEX_MUST_BE_UNIQUE = "Method parameter index must be unique.";
 
 	private static final Pattern NAME_WITH_COUNT_PATTERN = Pattern.compile("^(.*)\\s*\\((\\d+)\\)$"); // $NON-NLS-1$
 	private static final Pattern COUNT_SUFFIX_PATTERN = Pattern.compile("^\\s*\\((\\d+)\\)$"); // $NON-NLS-1$
@@ -269,7 +257,7 @@ public class Event implements IEvent {
 	@Override
 	public void setId(String id) {
 		if (id == null || id.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_ID_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_ID_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		this.id = id;
@@ -283,7 +271,7 @@ public class Event implements IEvent {
 	@Override
 	public void setName(String name) {
 		if (name == null || name.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		this.name = name;
@@ -297,12 +285,12 @@ public class Event implements IEvent {
 	@Override
 	public void setClazz(String clazz) {
 		if (clazz == null || clazz.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_CLASS_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_CLASS_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		clazz = clazz.trim();
 		if (!clazz.matches(CLAZZ_REGEX)) {
-			throw new IllegalArgumentException(ERROR_CLASS_HAS_INCORRECT_SYNTAX);
+			throw new IllegalArgumentException(Messages.Event_ERROR_CLASS_HAS_INCORRECT_SYNTAX);
 		}
 
 		this.clazz = clazz;
@@ -328,7 +316,7 @@ public class Event implements IEvent {
 		if (path != null) {
 			path = path.trim();
 			if (!path.matches(PATH_REGEX)) {
-				throw new IllegalArgumentException(ERROR_PATH_HAS_INCORRECT_SYNTAX);
+				throw new IllegalArgumentException(Messages.Event_ERROR_PATH_HAS_INCORRECT_SYNTAX);
 			}
 		}
 
@@ -374,12 +362,12 @@ public class Event implements IEvent {
 	@Override
 	public void setMethodName(String methodName) {
 		if (methodName == null || methodName.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_METHOD_NAME_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_METHOD_NAME_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		methodName = methodName.trim();
 		if (!methodName.matches(METHOD_NAME_REGEX)) {
-			throw new IllegalArgumentException(ERROR_METHOD_NAME_HAS_INCORRECT_SYNTAX);
+			throw new IllegalArgumentException(Messages.Event_ERROR_METHOD_NAME_HAS_INCORRECT_SYNTAX);
 		}
 
 		this.methodName = methodName;
@@ -393,12 +381,12 @@ public class Event implements IEvent {
 	@Override
 	public void setMethodDescriptor(String methodDescriptor) {
 		if (methodDescriptor == null || methodDescriptor.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_METHOD_DESCRIPTOR_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_METHOD_DESCRIPTOR_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		methodDescriptor = methodDescriptor.trim();
 		if (!methodDescriptor.matches(METHOD_DESCRIPTOR_REGEX)) {
-			throw new IllegalArgumentException(ERROR_METHOD_DESCRIPTOR_HAS_INCORRECT_SYNTAX);
+			throw new IllegalArgumentException(Messages.Event_ERROR_METHOD_DESCRIPTOR_HAS_INCORRECT_SYNTAX);
 		}
 
 		this.methodDescriptor = methodDescriptor;
@@ -412,10 +400,10 @@ public class Event implements IEvent {
 	@Override
 	public void addMethodParameter(IMethodParameter methodParameter) {
 		if (methodParameter == null) {
-			throw new IllegalArgumentException(ERROR_METHOD_PARAMETER_CANNOT_BE_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_METHOD_PARAMETER_CANNOT_BE_NULL);
 		}
 		if (containsIndex(methodParameter.getIndex())) {
-			throw new IllegalArgumentException(ERROR_INDEX_MUST_BE_UNIQUE);
+			throw new IllegalArgumentException(Messages.Event_ERROR_INDEX_MUST_BE_UNIQUE);
 		}
 
 		parameters.add(methodParameter);
@@ -449,7 +437,7 @@ public class Event implements IEvent {
 	@Override
 	public void addField(IField field) {
 		if (field == null) {
-			throw new IllegalArgumentException(ERROR_FIELD_CANNOT_BE_NULL);
+			throw new IllegalArgumentException(Messages.Event_ERROR_FIELD_CANNOT_BE_NULL);
 		}
 		fields.add(field);
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Field.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Field.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -45,10 +46,6 @@ public class Field extends CapturedValue implements IField {
 
 	private static final String XML_TAG_FIELD = "field"; // $NON-NLS-1$
 	private static final String XML_TAG_EXPRESSION = "expression"; // $NON-NLS-1$
-
-	private static final String ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL = "Name cannot be empty or null.";
-	private static final String ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL = "Expression cannot be empty or null.";
-	private static final String ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX = "Expression has incorrect syntax.";
 
 	private final Event event;
 
@@ -87,7 +84,7 @@ public class Field extends CapturedValue implements IField {
 	@Override
 	public void setName(String name) {
 		if (name == null || name.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Field_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		super.setName(name);
@@ -99,12 +96,12 @@ public class Field extends CapturedValue implements IField {
 
 	public void setExpression(String expression) {
 		if (expression == null || expression.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Field_ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		expression = expression.trim();
 		if (!expression.matches(EXPRESSION_REGEX)) {
-			throw new IllegalArgumentException(ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX);
+			throw new IllegalArgumentException(Messages.Field_ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX);
 		}
 
 		this.expression = expression;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodParameter.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -42,9 +43,6 @@ public class MethodParameter extends CapturedValue implements IMethodParameter {
 
 	private static final String XML_TAG_PARAMETER = "parameter"; // $NON-NLS-1$
 	private static final String XML_ATTRIBUTE_INDEX = "index"; // $NON-NLS-1$
-
-	private static final String ERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO = "Index cannot be less than zero.";
-	private static final String ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL = "Name cannot be empty or null.";
 
 	private final Event event;
 
@@ -76,7 +74,7 @@ public class MethodParameter extends CapturedValue implements IMethodParameter {
 	@Override
 	public void setName(String name) {
 		if (name == null || name.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.MethodParameter_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		super.setName(name);
@@ -90,7 +88,7 @@ public class MethodParameter extends CapturedValue implements IMethodParameter {
 	@Override
 	public void setIndex(int index) {
 		if (index < 0) {
-			throw new IllegalArgumentException(ERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO);
+			throw new IllegalArgumentException(Messages.MethodParameter_ERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO);
 		}
 
 		this.index = index;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Preset.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Preset.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.console.ext.agent.manager.model;
 
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ProbeValidator;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ValidationResult;
 import org.w3c.dom.Document;
@@ -68,10 +69,6 @@ public class Preset implements IPreset {
 	private static final String DEFAULT_FILE_NAME = "new_file.xml"; // $NON-NLS-1$
 	private static final String DEFAULT_CLASS_PREFIX = "__JFREvent"; // $NON-NLS-1$
 	private static final boolean DEFAULT_BOOLEAN_FIELD = false;
-
-	private static final String ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL = "File name cannot be empty or null.";
-	private static final String ERROR_MUST_HAVE_UNIQUE_ID = "An event with the same id already exists.";
-	private static final String ERROR_MUST_HAVE_UNIQUE_EVENT_CLASS_NAME = "Event must have a unique event name per class";
 
 	private static final String XML_TAG_JFR_AGENT = "jfragent"; // $NON-NLS-1$
 	private static final String XML_TAG_CONFIG = "config"; // $NON-NLS-1$
@@ -274,7 +271,7 @@ public class Preset implements IPreset {
 	@Override
 	public void setFileName(String fileName) {
 		if (fileName == null || fileName.isEmpty()) {
-			throw new IllegalArgumentException(ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL);
+			throw new IllegalArgumentException(Messages.Preset_ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL);
 		}
 
 		this.fileName = fileName;
@@ -322,10 +319,10 @@ public class Preset implements IPreset {
 	@Override
 	public void addEvent(IEvent event) {
 		if (containsId(event.getId())) {
-			throw new IllegalArgumentException(ERROR_MUST_HAVE_UNIQUE_ID);
+			throw new IllegalArgumentException(Messages.Preset_ERROR_MUST_HAVE_UNIQUE_ID);
 		}
 		if (containsEventClassName(event)) {
-			throw new IllegalArgumentException(ERROR_MUST_HAVE_UNIQUE_EVENT_CLASS_NAME);
+			throw new IllegalArgumentException(Messages.Preset_ERROR_MUST_HAVE_UNIQUE_EVENT_CLASS_NAME);
 		}
 
 		events.add(event);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/CapturedValueEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/CapturedValueEditingPage.java
@@ -17,34 +17,13 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IField;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 
 import java.util.Locale;
 import java.util.stream.Stream;
 
 public class CapturedValueEditingPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Captured Value Editing";
-
-	private static final String MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_TITLE = "Edit a Parameter or Return Value";
-	private static final String MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_DESCRIPTION = "Define a capturing of a method parameter or a return value.";
-	private static final String MESSAGE_FIELD_EDITING_PAGE_TITLE = "Edit a Parameter or Return Value Capturing";
-	private static final String MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION = "Define a custom expression evaluation and capture its result.";
-
-	private static final String LABEL_NAME = "Name: ";
-	private static final String LABEL_INDEX = "Index: ";
-	private static final String LABEL_IS_RETURN_VALUE = "This is a return value";
-	private static final String LABEL_EXPRESSION = "Expression: ";
-	private static final String LABEL_DESCRIPTION = "Description: ";
-	private static final String LABEL_CONTENT_TYPE = "Content Type: ";
-	private static final String LABEL_CLEAR = "Clear";
-	private static final String LABEL_RELATIONAL_KEY = "Relational Key: ";
-	private static final String LABEL_CONVERTER = "Converter: ";
-
-	private static final String MESSAGE_NAME_OF_THE_CAPTURING = "Name of this capturing";
-	private static final String MESSAGE_JAVA_PRIMARY_EXPRESSION_TO_BE_EVALUATED = "Java primary expression to be evaluated";
-	private static final String MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_CAPTURING = "(Optional) Description of this capturing";
-	private static final String MESSAGE_RELATIONAL_KEY_DESCRIPTION = "(Optional) Unique URI signifying a relationship";
-	private static final String MESSAGE_CONVERTER_DESCRIPTION = "(Optional) fully qualified class name of a value converter";
 
 	private final IEvent event;
 	private ICapturedValue capturedValue;
@@ -60,7 +39,7 @@ public class CapturedValueEditingPage extends BaseWizardPage {
 	private Text converterText;
 
 	public CapturedValueEditingPage(IEvent event, ICapturedValue capturedValue) {
-		super(PAGE_NAME);
+		super(Messages.CapturedValueEditingPage_PAGE_NAME);
 
 		this.event = event;
 		this.capturedValue = capturedValue;
@@ -71,14 +50,15 @@ public class CapturedValueEditingPage extends BaseWizardPage {
 		initializeDialogUnits(parent);
 
 		if (capturedValue instanceof IMethodParameter || capturedValue instanceof IMethodReturnValue) {
-			setTitle(MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_TITLE);
-			setDescription(MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_DESCRIPTION);
+			setTitle(Messages.CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_TITLE);
+			setDescription(
+					Messages.CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_DESCRIPTION);
 		} else if (capturedValue instanceof IField) {
-			setTitle(MESSAGE_FIELD_EDITING_PAGE_TITLE);
-			setDescription(MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION);
+			setTitle(Messages.CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_TITLE);
+			setDescription(Messages.CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION);
 		} else {
 			throw new IllegalStateException(
-					"captured value must be a an IMethodParameter, IMethodReturnValue or IFeild"); // $NON-NLS-1$
+					"captured value must be a an IMethodParameter, IMethodReturnValue or IField"); // $NON-NLS-1$
 		}
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
@@ -108,17 +88,18 @@ public class CapturedValueEditingPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		nameText = createTextInput(container, cols, LABEL_NAME, MESSAGE_NAME_OF_THE_CAPTURING);
+		nameText = createTextInput(container, cols, Messages.CapturedValueEditingPage_LABEL_NAME,
+				Messages.CapturedValueEditingPage_MESSAGE_NAME_OF_THE_CAPTURING);
 		if (capturedValue instanceof IField) {
-			expressionText = createTextInput(container, cols, LABEL_EXPRESSION,
-					MESSAGE_JAVA_PRIMARY_EXPRESSION_TO_BE_EVALUATED);
+			expressionText = createTextInput(container, cols, Messages.CapturedValueEditingPage_LABEL_EXPRESSION,
+					Messages.CapturedValueEditingPage_MESSAGE_JAVA_PRIMARY_EXPRESSION_TO_BE_EVALUATED);
 		} else {
-			indexSpinner = createSpinnerInput(container, 3, LABEL_INDEX);
-			isReturnValueButton = createCheckbox(container, LABEL_IS_RETURN_VALUE);
+			indexSpinner = createSpinnerInput(container, 3, Messages.CapturedValueEditingPage_LABEL_INDEX);
+			isReturnValueButton = createCheckbox(container, Messages.CapturedValueEditingPage_LABEL_IS_RETURN_VALUE);
 			isReturnValueButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 0));
 		}
-		descriptionText = createMultiTextInput(container, cols, LABEL_DESCRIPTION,
-				MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_CAPTURING);
+		descriptionText = createMultiTextInput(container, cols, Messages.CapturedValueEditingPage_LABEL_DESCRIPTION,
+				Messages.CapturedValueEditingPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_CAPTURING);
 
 		return container;
 	}
@@ -130,14 +111,16 @@ public class CapturedValueEditingPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		contentTypeCombo = createComboInput(container, cols - 2, LABEL_CONTENT_TYPE,
+		contentTypeCombo = createComboInput(container, cols - 2, Messages.CapturedValueEditingPage_LABEL_CONTENT_TYPE,
 				Stream.of(ContentType.values()).map(ContentType::toString).toArray(String[]::new));
-		contentTypeClearButton = createButton(container, LABEL_CLEAR);
+		contentTypeClearButton = createButton(container, Messages.CapturedValueEditingPage_LABEL_CLEAR);
 		contentTypeClearButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 0));
 
-		relationalKeyText = createTextInput(container, cols, LABEL_RELATIONAL_KEY, MESSAGE_RELATIONAL_KEY_DESCRIPTION);
+		relationalKeyText = createTextInput(container, cols, Messages.CapturedValueEditingPage_LABEL_RELATIONAL_KEY,
+				Messages.CapturedValueEditingPage_MESSAGE_RELATIONAL_KEY_DESCRIPTION);
 
-		converterText = createTextInput(container, cols, LABEL_CONVERTER, MESSAGE_CONVERTER_DESCRIPTION);
+		converterText = createTextInput(container, cols, Messages.CapturedValueEditingPage_LABEL_CONVERTER,
+				Messages.CapturedValueEditingPage_MESSAGE_CONVERTER_DESCRIPTION);
 
 		return container;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
@@ -46,34 +46,13 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent.Location;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 
 import java.util.Locale;
 import java.util.stream.Stream;
 
 public class EventEditingWizardConfigPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Event Editing";
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE = "Edit Event Configurations";
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION = "Edit basic information of an event on how it should be instrumented and injected.";
-
-	private static final String LABEL_ID = "ID: ";
-	private static final String LABEL_NAME = "Name: ";
-	private static final String LABEL_DESCRIPTION = "Description: ";
-	private static final String LABEL_CLASS = "Class: ";
-	private static final String LABEL_METHOD = "Method: ";
-	private static final String LABEL_PATH = "Path: ";
-	private static final String LABEL_LOCATION = "Location: ";
-	private static final String LABEL_CLEAR = "Clear";
-	private static final String LABEL_RECORD_EXCEPTIONS = "Record exceptions";
-	private static final String LABEL_RECORD_STACK_TRACE = "Record stack trace";
-
-	private static final String MESSAGE_EVENT_ID = "Event ID";
-	private static final String MESSAGE_NAME_OF_THE_EVENT = "Name of the event";
-	private static final String MESSAGE_FULLY_QUALIFIED_CLASS_NAME = "Fully qualified class name"; // $NON-NLS-1$
-	private static final String MESSAGE_METHOD_NAME = "Method name";
-	private static final String MESSAGE_METHOD_DESCRIPTOR = "Method descriptor";
-	private static final String MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_EVENT = "(Optional) Description of this event";
-	private static final String MESSAGE_PATH_TO_EVENT = "Path to event in event browser"; // $NON-NLS-1$
 
 	private final IEvent event;
 
@@ -90,7 +69,7 @@ public class EventEditingWizardConfigPage extends BaseWizardPage {
 	private Button recordStackTraceButton;
 
 	protected EventEditingWizardConfigPage(IEvent event) {
-		super(PAGE_NAME);
+		super(Messages.EventEditingWizardConfigPage_PAGE_NAME);
 
 		this.event = event;
 	}
@@ -104,8 +83,8 @@ public class EventEditingWizardConfigPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE);
-		setDescription(MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION);
+		setTitle(Messages.EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE);
+		setDescription(Messages.EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -136,10 +115,12 @@ public class EventEditingWizardConfigPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		idText = createTextInput(container, cols, LABEL_ID, MESSAGE_EVENT_ID);
-		nameText = createTextInput(container, cols, LABEL_NAME, MESSAGE_NAME_OF_THE_EVENT);
-		descriptionText = createMultiTextInput(container, cols, LABEL_DESCRIPTION,
-				MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_EVENT);
+		idText = createTextInput(container, cols, Messages.EventEditingWizardConfigPage_LABEL_ID,
+				Messages.EventEditingWizardConfigPage_MESSAGE_EVENT_ID);
+		nameText = createTextInput(container, cols, Messages.EventEditingWizardConfigPage_LABEL_NAME,
+				Messages.EventEditingWizardConfigPage_MESSAGE_NAME_OF_THE_EVENT);
+		descriptionText = createMultiTextInput(container, cols, Messages.EventEditingWizardConfigPage_LABEL_DESCRIPTION,
+				Messages.EventEditingWizardConfigPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_EVENT);
 
 		return container;
 	}
@@ -151,9 +132,12 @@ public class EventEditingWizardConfigPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		classText = createTextInput(container, cols, LABEL_CLASS, MESSAGE_FULLY_QUALIFIED_CLASS_NAME);
-		Text[] receivers = createMultiInputTextInput(container, cols, LABEL_METHOD,
-				new String[] {MESSAGE_METHOD_NAME, MESSAGE_METHOD_DESCRIPTOR});
+		classText = createTextInput(container, cols, Messages.EventEditingWizardConfigPage_LABEL_CLASS,
+				Messages.EventEditingWizardConfigPage_MESSAGE_FULLY_QUALIFIED_CLASS_NAME); // $NON-NLS-1$
+		Text[] receivers = createMultiInputTextInput(container, cols,
+				Messages.EventEditingWizardConfigPage_LABEL_METHOD,
+				new String[] {Messages.EventEditingWizardConfigPage_MESSAGE_METHOD_NAME,
+						Messages.EventEditingWizardConfigPage_MESSAGE_METHOD_DESCRIPTOR});
 
 		methodNameText = receivers[0];
 		methodDescriptorText = receivers[1];
@@ -168,14 +152,17 @@ public class EventEditingWizardConfigPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		pathText = createTextInput(container, cols, LABEL_PATH, MESSAGE_PATH_TO_EVENT);
-		locationCombo = createComboInput(container, cols - 2, LABEL_LOCATION,
+		pathText = createTextInput(container, cols, Messages.EventEditingWizardConfigPage_LABEL_PATH,
+				Messages.EventEditingWizardConfigPage_MESSAGE_PATH_TO_EVENT); // $NON-NLS-1$
+		locationCombo = createComboInput(container, cols - 2, Messages.EventEditingWizardConfigPage_LABEL_LOCATION,
 				Stream.of(Location.values()).map(Location::toString).toArray(String[]::new));
-		locationClearButton = createButton(container, LABEL_CLEAR);
+		locationClearButton = createButton(container, Messages.EventEditingWizardConfigPage_LABEL_CLEAR);
 		locationClearButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 0));
 
-		recordExceptionsButton = createCheckboxInput(container, cols, LABEL_RECORD_EXCEPTIONS);
-		recordStackTraceButton = createCheckboxInput(container, cols, LABEL_RECORD_STACK_TRACE);
+		recordExceptionsButton = createCheckboxInput(container, cols,
+				Messages.EventEditingWizardConfigPage_LABEL_RECORD_EXCEPTIONS);
+		recordStackTraceButton = createCheckboxInput(container, cols,
+				Messages.EventEditingWizardConfigPage_LABEL_RECORD_STACK_TRACE);
 
 		return container;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
@@ -44,32 +44,20 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IField;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 import org.openjdk.jmc.ui.misc.AbstractStructuredContentProvider;
 import org.openjdk.jmc.ui.misc.DialogToolkit;
 import org.openjdk.jmc.ui.wizards.OnePageWizardDialog;
 
 public class EventEditingWizardFieldPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Event Editing";
-
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_TITLE = "Add or Remove Event Fields";
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_DESCRIPTION = "Fields are a subset of Java primary expressions which can be evaluated and recorded when committing an event.";
-	private static final String MESSAGE_UNABLE_TO_SAVE_THE_FIELD = "Unable to add the field";
-
-	private static final String LABEL_NAME = "Name";
-	private static final String LABEL_EXPRESSION = "Expression";
-	private static final String LABEL_DESCRIPTION = "Description";
-
-	private static final String ID_NAME = "name";
-	private static final String ID_EXPRESSION = "expression";
-	private static final String ID_DESCRIPTION = "description";
 
 	private final IEvent event;
 
 	private TableInspector tableInspector;
 
 	protected EventEditingWizardFieldPage(IEvent event) {
-		super(PAGE_NAME);
+		super(Messages.EventEditingWizardFieldPage_PAGE_NAME);
 
 		this.event = event;
 	}
@@ -78,8 +66,8 @@ public class EventEditingWizardFieldPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_TITLE);
-		setDescription(MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_DESCRIPTION);
+		setTitle(Messages.EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_TITLE);
+		setDescription(Messages.EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -106,26 +94,29 @@ public class EventEditingWizardFieldPage extends BaseWizardPage {
 						| TableInspector.EDIT_BUTTON | TableInspector.DUPLICATE_BUTTON | TableInspector.REMOVE_BUTTON) {
 			@Override
 			protected void addColumns() {
-				addColumn(LABEL_NAME, ID_NAME, new FieldTableLabelProvider() {
-					@Override
-					protected String doGetText(IField field) {
-						return field.getName();
-					}
-				});
+				addColumn(Messages.EventEditingWizardFieldPage_LABEL_NAME, Messages.EventEditingWizardFieldPage_ID_NAME,
+						new FieldTableLabelProvider() {
+							@Override
+							protected String doGetText(IField field) {
+								return field.getName();
+							}
+						});
 
-				addColumn(LABEL_EXPRESSION, ID_EXPRESSION, new FieldTableLabelProvider() {
-					@Override
-					protected String doGetText(IField field) {
-						return field.getExpression();
-					}
-				});
+				addColumn(Messages.EventEditingWizardFieldPage_LABEL_EXPRESSION,
+						Messages.EventEditingWizardFieldPage_ID_EXPRESSION, new FieldTableLabelProvider() {
+							@Override
+							protected String doGetText(IField field) {
+								return field.getExpression();
+							}
+						});
 
-				addColumn(LABEL_DESCRIPTION, ID_DESCRIPTION, new FieldTableLabelProvider() {
-					@Override
-					protected String doGetText(IField field) {
-						return field.getDescription();
-					}
-				});
+				addColumn(Messages.EventEditingWizardFieldPage_LABEL_DESCRIPTION,
+						Messages.EventEditingWizardFieldPage_ID_DESCRIPTION, new FieldTableLabelProvider() {
+							@Override
+							protected String doGetText(IField field) {
+								return field.getDescription();
+							}
+						});
 			}
 
 			@Override
@@ -136,7 +127,9 @@ public class EventEditingWizardFieldPage extends BaseWizardPage {
 					try {
 						event.addField(field);
 					} catch (IllegalArgumentException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_UNABLE_TO_SAVE_THE_FIELD, e.getMessage())) {
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.EventEditingWizardFieldPage_MESSAGE_UNABLE_TO_SAVE_THE_FIELD,
+								e.getMessage())) {
 							continue;
 						}
 					}
@@ -156,7 +149,9 @@ public class EventEditingWizardFieldPage extends BaseWizardPage {
 					try {
 						event.updateField(original, workingCopy);
 					} catch (IllegalArgumentException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_UNABLE_TO_SAVE_THE_FIELD, e.getMessage())) {
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.EventEditingWizardFieldPage_MESSAGE_UNABLE_TO_SAVE_THE_FIELD,
+								e.getMessage())) {
 							continue;
 						}
 					}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.console.ext.agent.manager.model.IMethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.IMethodReturnValue;
 import org.openjdk.jmc.console.ext.agent.manager.model.MethodParameter;
 import org.openjdk.jmc.console.ext.agent.manager.model.MethodReturnValue;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 import org.openjdk.jmc.ui.misc.AbstractStructuredContentProvider;
 import org.openjdk.jmc.ui.misc.DialogToolkit;
@@ -58,27 +59,13 @@ import java.util.Arrays;
 import java.util.List;
 
 public class EventEditingWizardParameterPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Event Editing";
-
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_TITLE = "Add or Remove Event Parameters";
-	private static final String MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_DESCRIPTION = "Function parameters and return values can be recorded when committing an event.";
-	private static final String MESSAGE_RETURN_VALUE = "(Return value)";
-	private static final String MESSAGE_UNABLE_TO_SAVE_THE_PARAMETER_OR_RETURN_VALUE = "Unable to add the parameter/return value";
-
-	private static final String LABEL_INDEX = "Index";
-	private static final String LABEL_NAME = "Name";
-	private static final String LABEL_DESCRIPTION = "Description";
-
-	private static final String ID_INDEX = "index";
-	private static final String ID_NAME = "name";
-	private static final String ID_DESCRIPTION = "description";
 
 	private final IEvent event;
 
 	private TableInspector tableInspector;
 
 	protected EventEditingWizardParameterPage(IEvent event) {
-		super(PAGE_NAME);
+		super(Messages.EventEditingWizardParameterPage_PAGE_NAME);
 
 		this.event = event;
 	}
@@ -87,8 +74,9 @@ public class EventEditingWizardParameterPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_TITLE);
-		setDescription(MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_DESCRIPTION);
+		setTitle(Messages.EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_TITLE);
+		setDescription(
+				Messages.EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -114,35 +102,38 @@ public class EventEditingWizardParameterPage extends BaseWizardPage {
 				| TableInspector.ADD_BUTTON | TableInspector.EDIT_BUTTON | TableInspector.REMOVE_BUTTON) {
 			@Override
 			protected void addColumns() {
-				addColumn(LABEL_INDEX, ID_INDEX, new ParameterTableLabelProvider() {
-					@Override
-					protected String doGetText(ICapturedValue parameter) {
-						if (parameter instanceof IMethodReturnValue) {
-							return MESSAGE_RETURN_VALUE;
-						}
+				addColumn(Messages.EventEditingWizardParameterPage_LABEL_INDEX,
+						Messages.EventEditingWizardParameterPage_ID_INDEX, new ParameterTableLabelProvider() {
+							@Override
+							protected String doGetText(ICapturedValue parameter) {
+								if (parameter instanceof IMethodReturnValue) {
+									return Messages.EventEditingWizardParameterPage_MESSAGE_RETURN_VALUE;
+								}
 
-						if (parameter instanceof IMethodParameter) {
-							return ((IMethodParameter) parameter).getIndex() + "";
-						}
+								if (parameter instanceof IMethodParameter) {
+									return ((IMethodParameter) parameter).getIndex() + "";
+								}
 
-						throw new IllegalArgumentException(
-								"element must be a an IMethodParameter or IMethodReturnValue"); // $NON-NLS-1$
-					}
-				});
+								throw new IllegalArgumentException(
+										"element must be a an IMethodParameter or IMethodReturnValue"); // $NON-NLS-1$
+							}
+						});
 
-				addColumn(LABEL_NAME, ID_NAME, new ParameterTableLabelProvider() {
-					@Override
-					protected String doGetText(ICapturedValue parameter) {
-						return parameter.getName();
-					}
-				});
+				addColumn(Messages.EventEditingWizardParameterPage_LABEL_NAME,
+						Messages.EventEditingWizardParameterPage_ID_NAME, new ParameterTableLabelProvider() {
+							@Override
+							protected String doGetText(ICapturedValue parameter) {
+								return parameter.getName();
+							}
+						});
 
-				addColumn(LABEL_DESCRIPTION, ID_DESCRIPTION, new ParameterTableLabelProvider() {
-					@Override
-					protected String doGetText(ICapturedValue parameter) {
-						return parameter.getDescription();
-					}
-				});
+				addColumn(Messages.EventEditingWizardParameterPage_LABEL_DESCRIPTION,
+						Messages.EventEditingWizardParameterPage_ID_DESCRIPTION, new ParameterTableLabelProvider() {
+							@Override
+							protected String doGetText(ICapturedValue parameter) {
+								return parameter.getDescription();
+							}
+						});
 			}
 
 			@Override
@@ -158,7 +149,8 @@ public class EventEditingWizardParameterPage extends BaseWizardPage {
 							event.setMethodReturnValue((IMethodReturnValue) capturedValue);
 						}
 					} catch (IllegalArgumentException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_UNABLE_TO_SAVE_THE_PARAMETER_OR_RETURN_VALUE,
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.EventEditingWizardParameterPage_MESSAGE_UNABLE_TO_SAVE_THE_PARAMETER_OR_RETURN_VALUE,
 								e.getMessage())) {
 							continue;
 						}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardConfigPage.java
@@ -43,21 +43,10 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.console.ext.agent.manager.model.IPreset;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 
 public class PresetEditingWizardConfigPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Preset Editing";
-
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_TITLE = "Edit Preset Global Configurations";
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION = "Global configurations are defaults which applies to any event missing a per-even configuration.";
-
-	private static final String LABEL_FILE_NAME = "File Name: ";
-	private static final String LABEL_CLASS_PREFIX = "Class Prefix: ";
-	private static final String LABEL_ALLOW_TO_STRING = "Allow toString";
-	private static final String LABEL_ALLOW_CONVERTER = "Allow Converter";
-
-	private static final String MESSAGE_NAME_OF_THE_SAVED_XML = "Name of the saved XML on file system";
-	private static final String MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES = "Prefix added to generated event classes";
 
 	private final IPreset preset;
 
@@ -67,7 +56,7 @@ public class PresetEditingWizardConfigPage extends BaseWizardPage {
 	private Button allowConverterButton;
 
 	protected PresetEditingWizardConfigPage(IPreset preset) {
-		super(PAGE_NAME);
+		super(Messages.PresetEditingWizardConfigPage_PAGE_NAME);
 
 		this.preset = preset;
 	}
@@ -76,8 +65,8 @@ public class PresetEditingWizardConfigPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_TITLE);
-		setDescription(MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION);
+		setTitle(Messages.PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_TITLE);
+		setDescription(Messages.PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -105,7 +94,8 @@ public class PresetEditingWizardConfigPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		fileNameText = createTextInput(container, cols, LABEL_FILE_NAME, MESSAGE_NAME_OF_THE_SAVED_XML);
+		fileNameText = createTextInput(container, cols, Messages.PresetEditingWizardConfigPage_LABEL_FILE_NAME,
+				Messages.PresetEditingWizardConfigPage_MESSAGE_NAME_OF_THE_SAVED_XML);
 
 		return container;
 	}
@@ -117,10 +107,12 @@ public class PresetEditingWizardConfigPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		classPrefixText = createTextInput(container, cols, LABEL_CLASS_PREFIX,
-				MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES);
-		allowToStringButton = createCheckboxInput(parent, cols, LABEL_ALLOW_TO_STRING);
-		allowConverterButton = createCheckboxInput(parent, cols, LABEL_ALLOW_CONVERTER);
+		classPrefixText = createTextInput(container, cols, Messages.PresetEditingWizardConfigPage_LABEL_CLASS_PREFIX,
+				Messages.PresetEditingWizardConfigPage_MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES);
+		allowToStringButton = createCheckboxInput(parent, cols,
+				Messages.PresetEditingWizardConfigPage_LABEL_ALLOW_TO_STRING);
+		allowConverterButton = createCheckboxInput(parent, cols,
+				Messages.PresetEditingWizardConfigPage_LABEL_ALLOW_CONVERTER);
 
 		return container;
 	}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardEventPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardEventPage.java
@@ -42,29 +42,19 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.openjdk.jmc.console.ext.agent.manager.model.IEvent;
 import org.openjdk.jmc.console.ext.agent.manager.model.IPreset;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 import org.openjdk.jmc.ui.misc.AbstractStructuredContentProvider;
 import org.openjdk.jmc.ui.misc.DialogToolkit;
 
 public class PresetEditingWizardEventPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Preset Editing";
-
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_TITLE = "Add or Remove Preset Events";
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_DESCRIPTION = "Add new events to the preset, or remove/edit existing events.";
-	private static final String MESSAGE_UNABLE_TO_SAVE_THE_PRESET = "Unable to add the event";
-
-	private static final String LABEL_ID_COLUMN = "ID";
-	private static final String LABEL_NAME_COLUMN = "Name";
-
-	private static final String ID_ID_COLUMN = "id";
-	private static final String ID_NAME_COLUMN = "name";
 
 	private final IPreset preset;
 
 	private TableInspector tableInspector;
 
 	protected PresetEditingWizardEventPage(IPreset preset) {
-		super(PAGE_NAME);
+		super(Messages.PresetEditingWizardEventPage_PAGE_NAME);
 
 		this.preset = preset;
 	}
@@ -73,8 +63,8 @@ public class PresetEditingWizardEventPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_TITLE);
-		setDescription(MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_DESCRIPTION);
+		setTitle(Messages.PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_TITLE);
+		setDescription(Messages.PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -101,19 +91,21 @@ public class PresetEditingWizardEventPage extends BaseWizardPage {
 						| TableInspector.EDIT_BUTTON | TableInspector.DUPLICATE_BUTTON | TableInspector.REMOVE_BUTTON) {
 			@Override
 			protected void addColumns() {
-				addColumn(LABEL_ID_COLUMN, ID_ID_COLUMN, new EventTableLabelProvider() {
-					@Override
-					protected String doGetText(IEvent event) {
-						return event.getId();
-					}
-				});
+				addColumn(Messages.PresetEditingWizardEventPage_LABEL_ID_COLUMN,
+						Messages.PresetEditingWizardEventPage_ID_ID_COLUMN, new EventTableLabelProvider() {
+							@Override
+							protected String doGetText(IEvent event) {
+								return event.getId();
+							}
+						});
 
-				addColumn(LABEL_NAME_COLUMN, ID_NAME_COLUMN, new EventTableLabelProvider() {
-					@Override
-					protected String doGetText(IEvent event) {
-						return event.getName();
-					}
-				});
+				addColumn(Messages.PresetEditingWizardEventPage_LABEL_NAME_COLUMN,
+						Messages.PresetEditingWizardEventPage_ID_NAME_COLUMN, new EventTableLabelProvider() {
+							@Override
+							protected String doGetText(IEvent event) {
+								return event.getName();
+							}
+						});
 			}
 
 			@Override
@@ -123,7 +115,9 @@ public class PresetEditingWizardEventPage extends BaseWizardPage {
 					try {
 						preset.addEvent(event);
 					} catch (IllegalArgumentException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_UNABLE_TO_SAVE_THE_PRESET, e.getMessage())) {
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.PresetEditingWizardEventPage_MESSAGE_UNABLE_TO_SAVE_THE_PRESET,
+								e.getMessage())) {
 							continue;
 						}
 					}
@@ -142,7 +136,9 @@ public class PresetEditingWizardEventPage extends BaseWizardPage {
 					try {
 						preset.updateEvent(original, workingCopy);
 					} catch (IllegalArgumentException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_UNABLE_TO_SAVE_THE_PRESET, e.getMessage())) {
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.PresetEditingWizardEventPage_MESSAGE_UNABLE_TO_SAVE_THE_PRESET,
+								e.getMessage())) {
 							continue;
 						}
 					}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardPreviewPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardPreviewPage.java
@@ -44,22 +44,20 @@ import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.openjdk.jmc.console.ext.agent.manager.model.IPreset;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.ColorManager;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlConfiguration;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlPartitionScanner;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 
 public class PresetEditingWizardPreviewPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Preset Editing";
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_TITLE = "Preview Preset Output";
-	private static final String MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_DESCRIPTION = "Inspects the generated XML before it is saved. Click Back to make any modifications if needed. Click Finish to save.";
 
 	private IPreset preset;
 
 	private IDocument document;
 
 	protected PresetEditingWizardPreviewPage(IPreset preset) {
-		super(PAGE_NAME);
+		super(Messages.PresetEditingWizardPreviewPage_PAGE_NAME);
 
 		this.preset = preset;
 	}
@@ -68,8 +66,8 @@ public class PresetEditingWizardPreviewPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_TITLE);
-		setDescription(MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_DESCRIPTION);
+		setTitle(Messages.PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_TITLE);
+		setDescription(Messages.PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetManagerPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetManagerPage.java
@@ -43,6 +43,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
 import org.openjdk.jmc.console.ext.agent.manager.model.IPreset;
 import org.openjdk.jmc.console.ext.agent.manager.model.PresetRepository;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
 import org.openjdk.jmc.ui.misc.AbstractStructuredContentProvider;
 import org.openjdk.jmc.ui.misc.DialogToolkit;
@@ -52,16 +53,6 @@ import java.io.File;
 import java.io.IOException;
 
 public class PresetManagerPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Agent Preset Manager";
-
-	private static final String MESSAGE_PRESET_MANAGER_PAGE_TITLE = "JMC Agent Configuration Preset Manager";
-	private static final String MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION = "Presets for JMC agent are useful to repeatedly apply configurations to a running JMC agent.";
-	private static final String MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET = "Unable to save the preset";
-	private static final String MESSAGE_PRESET_MANAGER_UNABLE_TO_IMPORT_THE_PRESET = "Unable to import the preset";
-	private static final String MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET = "Unable to export the preset";
-	private static final String MESSAGE_IMPORT_EXTERNAL_PRESET_FILES = "Import external preset files";
-	private static final String MESSAGE_EXPORT_PRESET_TO_A_FILE = "Import the preset to a file";
-	private static final String MESSAGE_EVENTS = "event(s)";
 
 	private static final String ID_PRESET = "preset"; // $NON-NLS-1$
 	private static final String PRESET_XML_EXTENSION = "*.xml"; // $NON-NLS-1$
@@ -71,7 +62,7 @@ public class PresetManagerPage extends BaseWizardPage {
 	private TableInspector tableInspector;
 
 	public PresetManagerPage(PresetRepository repository) {
-		super(PAGE_NAME);
+		super(Messages.PresetManagerPage_PAGE_NAME);
 
 		this.repository = repository;
 	}
@@ -80,8 +71,8 @@ public class PresetManagerPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_PRESET_MANAGER_PAGE_TITLE);
-		setDescription(MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION);
+		setTitle(Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_TITLE);
+		setDescription(Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -117,7 +108,8 @@ public class PresetManagerPage extends BaseWizardPage {
 						}
 
 						IPreset preset = (IPreset) element;
-						return preset.getFileName() + " - " + preset.getEvents().length + " " + MESSAGE_EVENTS;
+						return preset.getFileName() + " - " + preset.getEvents().length + " "
+								+ Messages.PresetManagerPage_MESSAGE_EVENTS;
 					}
 
 					@Override
@@ -134,7 +126,8 @@ public class PresetManagerPage extends BaseWizardPage {
 					try {
 						repository.addPreset(preset);
 					} catch (IllegalArgumentException | IOException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
 								e.getLocalizedMessage())) {
 							continue;
 						}
@@ -154,7 +147,8 @@ public class PresetManagerPage extends BaseWizardPage {
 					try {
 						repository.updatePreset(original, workingCopy);
 					} catch (IllegalArgumentException | IOException e) {
-						if (DialogToolkit.openConfirmOnUiThread(MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
+						if (DialogToolkit.openConfirmOnUiThread(
+								Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
 								e.getLocalizedMessage())) {
 							continue;
 						}
@@ -174,7 +168,8 @@ public class PresetManagerPage extends BaseWizardPage {
 				try {
 					repository.addPreset(duplicate);
 				} catch (IllegalArgumentException | IOException e) {
-					DialogToolkit.openConfirmOnUiThread(MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
+					DialogToolkit.openConfirmOnUiThread(
+							Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET,
 							e.getLocalizedMessage());
 				}
 
@@ -192,7 +187,7 @@ public class PresetManagerPage extends BaseWizardPage {
 
 			@Override
 			protected void onImportFilesButtonSelected(IStructuredSelection selection) {
-				String[] files = openFileDialog(MESSAGE_IMPORT_EXTERNAL_PRESET_FILES,
+				String[] files = openFileDialog(Messages.PresetManagerPage_MESSAGE_IMPORT_EXTERNAL_PRESET_FILES,
 						new String[] {PRESET_XML_EXTENSION}, SWT.OPEN | SWT.MULTI);
 				if (files != null) {
 					for (String path : files) {
@@ -200,7 +195,8 @@ public class PresetManagerPage extends BaseWizardPage {
 						try {
 							repository.importPreset(file);
 						} catch (IOException | SAXException e) {
-							DialogToolkit.openConfirmOnUiThread(MESSAGE_PRESET_MANAGER_UNABLE_TO_IMPORT_THE_PRESET,
+							DialogToolkit.openConfirmOnUiThread(
+									Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_IMPORT_THE_PRESET,
 									e.getLocalizedMessage());
 						}
 					}
@@ -211,8 +207,8 @@ public class PresetManagerPage extends BaseWizardPage {
 
 			@Override
 			protected void onExportFileButtonSelected(IStructuredSelection selection) {
-				String[] files = openFileDialog(MESSAGE_EXPORT_PRESET_TO_A_FILE, new String[] {PRESET_XML_EXTENSION},
-						SWT.SAVE | SWT.SINGLE);
+				String[] files = openFileDialog(Messages.PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE,
+						new String[] {PRESET_XML_EXTENSION}, SWT.SAVE | SWT.SINGLE);
 				if (files == null || files.length == 0) {
 					return;
 				}
@@ -221,7 +217,8 @@ public class PresetManagerPage extends BaseWizardPage {
 				try {
 					repository.exportPreset((IPreset) selection.getFirstElement(), file);
 				} catch (IOException e) {
-					DialogToolkit.openConfirmOnUiThread(MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET,
+					DialogToolkit.openConfirmOnUiThread(
+							Messages.PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET,
 							e.getLocalizedMessage());
 				}
 			}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.console.ext.agent.messages.internal;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = "org.openjdk.jmc.console.ext.agent.messages.internal.messages"; //$NON-NLS-1$
+	public static String AgentEditorOpener_JOB_NAME;
+	public static String AgentEditorOpener_MESSAGE_COULD_NOT_CONNECT;
+	public static String AgentEditorOpener_MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED;
+	public static String AgentEditorOpener_MESSAGE_START_AGENT_MANUALLY;
+	public static String AgentEditorOpener_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR;
+	public static String AgentEditor_CONNECTION_LOST;
+	public static String AgentEditor_COULD_NOT_CONNECT;
+	public static String CapturedValue_ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX;
+	public static String CapturedValue_ERROR_CONVERTER_HAS_INCORRECT_SYNTAX;
+	public static String Event_ERROR_ID_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Event_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Event_ERROR_CLASS_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Event_ERROR_METHOD_NAME_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Event_ERROR_METHOD_DESCRIPTOR_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Event_ERROR_METHOD_PARAMETER_CANNOT_BE_NULL;
+	public static String Event_ERROR_FIELD_CANNOT_BE_NULL;
+	public static String Event_ERROR_CLASS_HAS_INCORRECT_SYNTAX;
+	public static String Event_ERROR_PATH_HAS_INCORRECT_SYNTAX;
+	public static String Event_ERROR_METHOD_NAME_HAS_INCORRECT_SYNTAX;
+	public static String Event_ERROR_METHOD_DESCRIPTOR_HAS_INCORRECT_SYNTAX;
+	public static String Event_ERROR_INDEX_MUST_BE_UNIQUE;
+	public static String Field_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Field_ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Field_ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX;
+	public static String MethodParameter_ERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO;
+	public static String MethodParameter_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Preset_ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL;
+	public static String Preset_ERROR_MUST_HAVE_UNIQUE_ID;
+	public static String Preset_ERROR_MUST_HAVE_UNIQUE_EVENT_CLASS_NAME;
+	public static String CapturedValueEditingPage_PAGE_NAME;
+	public static String CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_TITLE;
+	public static String CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_DESCRIPTION;
+	public static String CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_TITLE;
+	public static String CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION;
+	public static String CapturedValueEditingPage_LABEL_NAME;
+	public static String CapturedValueEditingPage_LABEL_INDEX;
+	public static String CapturedValueEditingPage_LABEL_IS_RETURN_VALUE;
+	public static String CapturedValueEditingPage_LABEL_EXPRESSION;
+	public static String CapturedValueEditingPage_LABEL_DESCRIPTION;
+	public static String CapturedValueEditingPage_LABEL_CONTENT_TYPE;
+	public static String CapturedValueEditingPage_LABEL_CLEAR;
+	public static String CapturedValueEditingPage_LABEL_RELATIONAL_KEY;
+	public static String CapturedValueEditingPage_LABEL_CONVERTER;
+	public static String CapturedValueEditingPage_MESSAGE_NAME_OF_THE_CAPTURING;
+	public static String CapturedValueEditingPage_MESSAGE_JAVA_PRIMARY_EXPRESSION_TO_BE_EVALUATED;
+	public static String CapturedValueEditingPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_CAPTURING;
+	public static String CapturedValueEditingPage_MESSAGE_RELATIONAL_KEY_DESCRIPTION;
+	public static String CapturedValueEditingPage_MESSAGE_CONVERTER_DESCRIPTION;
+	public static String EventEditingWizardConfigPage_PAGE_NAME;
+	public static String EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE;
+	public static String EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION;
+	public static String EventEditingWizardConfigPage_LABEL_ID;
+	public static String EventEditingWizardConfigPage_LABEL_NAME;
+	public static String EventEditingWizardConfigPage_LABEL_DESCRIPTION;
+	public static String EventEditingWizardConfigPage_LABEL_CLASS;
+	public static String EventEditingWizardConfigPage_LABEL_METHOD;
+	public static String EventEditingWizardConfigPage_LABEL_PATH;
+	public static String EventEditingWizardConfigPage_LABEL_LOCATION;
+	public static String EventEditingWizardConfigPage_LABEL_CLEAR;
+	public static String EventEditingWizardConfigPage_LABEL_RECORD_EXCEPTIONS;
+	public static String EventEditingWizardConfigPage_LABEL_RECORD_STACK_TRACE;
+	public static String EventEditingWizardConfigPage_MESSAGE_EVENT_ID;
+	public static String EventEditingWizardConfigPage_MESSAGE_NAME_OF_THE_EVENT;
+	public static String EventEditingWizardConfigPage_MESSAGE_FULLY_QUALIFIED_CLASS_NAME;
+	public static String EventEditingWizardConfigPage_MESSAGE_METHOD_NAME;
+	public static String EventEditingWizardConfigPage_MESSAGE_METHOD_DESCRIPTOR;
+	public static String EventEditingWizardConfigPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_EVENT;
+	public static String EventEditingWizardConfigPage_MESSAGE_PATH_TO_EVENT;
+	public static String EventEditingWizardFieldPage_PAGE_NAME;
+	public static String EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_TITLE;
+	public static String EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_DESCRIPTION;
+	public static String EventEditingWizardFieldPage_MESSAGE_UNABLE_TO_SAVE_THE_FIELD;
+	public static String EventEditingWizardFieldPage_LABEL_NAME;
+	public static String EventEditingWizardFieldPage_LABEL_EXPRESSION;
+	public static String EventEditingWizardFieldPage_LABEL_DESCRIPTION;
+	public static String EventEditingWizardFieldPage_ID_NAME;
+	public static String EventEditingWizardFieldPage_ID_EXPRESSION;
+	public static String EventEditingWizardFieldPage_ID_DESCRIPTION;
+	public static String EventEditingWizardParameterPage_PAGE_NAME;
+	public static String EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_TITLE;
+	public static String EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_DESCRIPTION;
+	public static String EventEditingWizardParameterPage_MESSAGE_RETURN_VALUE;
+	public static String EventEditingWizardParameterPage_MESSAGE_UNABLE_TO_SAVE_THE_PARAMETER_OR_RETURN_VALUE;
+	public static String EventEditingWizardParameterPage_LABEL_INDEX;
+	public static String EventEditingWizardParameterPage_LABEL_NAME;
+	public static String EventEditingWizardParameterPage_LABEL_DESCRIPTION;
+	public static String EventEditingWizardParameterPage_ID_INDEX;
+	public static String EventEditingWizardParameterPage_ID_NAME;
+	public static String EventEditingWizardParameterPage_ID_DESCRIPTION;
+	public static String PresetEditingWizardConfigPage_PAGE_NAME;
+	public static String PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_TITLE;
+	public static String PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION;
+	public static String PresetEditingWizardConfigPage_LABEL_FILE_NAME;
+	public static String PresetEditingWizardConfigPage_LABEL_CLASS_PREFIX;
+	public static String PresetEditingWizardConfigPage_LABEL_ALLOW_TO_STRING;
+	public static String PresetEditingWizardConfigPage_LABEL_ALLOW_CONVERTER;
+	public static String PresetEditingWizardConfigPage_MESSAGE_NAME_OF_THE_SAVED_XML;
+	public static String PresetEditingWizardConfigPage_MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES;
+	public static String PresetEditingWizardEventPage_PAGE_NAME;
+	public static String PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_TITLE;
+	public static String PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_DESCRIPTION;
+	public static String PresetEditingWizardEventPage_MESSAGE_UNABLE_TO_SAVE_THE_PRESET;
+	public static String PresetEditingWizardEventPage_LABEL_ID_COLUMN;
+	public static String PresetEditingWizardEventPage_LABEL_NAME_COLUMN;
+	public static String PresetEditingWizardEventPage_ID_ID_COLUMN;
+	public static String PresetEditingWizardEventPage_ID_NAME_COLUMN;
+	public static String PresetEditingWizardPreviewPage_PAGE_NAME;
+	public static String PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_TITLE;
+	public static String PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_DESCRIPTION;
+	public static String PresetManagerPage_PAGE_NAME;
+	public static String PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_TITLE;
+	public static String PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION;
+	public static String PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET;
+	public static String PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_IMPORT_THE_PRESET;
+	public static String PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET;
+	public static String PresetManagerPage_MESSAGE_IMPORT_EXTERNAL_PRESET_FILES;
+	public static String PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE;
+	public static String PresetManagerPage_MESSAGE_EVENTS;
+	public static String EditorTab_TITLE;
+	public static String ActionButtons_LABEL_SAVE_TO_PRESET_BUTTON;
+	public static String ActionButtons_LABEL_SAVE_TO_FILE_BUTTON;
+	public static String ActionButtons_LABEL_APPLY_PRESET_BUTTON;
+	public static String ActionButtons_LABEL_APPLY_LOCAL_CONFIG_BUTTON;
+	public static String ActionButtons_ERROR_PAGE_TITLE;
+	public static String ActionButtons_MESSAGE_APPLY_LOCAL_CONFIG;
+	public static String LiveConfigTab_TITLE;
+	public static String OverviewTab_TITLE;
+	public static String OverviewTab_MESSAGE_AGENT_LOADED;
+	public static String EditAgentSection_MESSAGE_ENTER_PATH;
+	public static String EditAgentSection_MESSAGE_AGENT_XML_PATH;
+	public static String EditAgentSection_MESSAGE_BROWSE;
+	public static String EditAgentSection_MESSAGE_EDIT;
+	public static String EditAgentSection_MESSAGE_VALIDATE;
+	public static String EditAgentSection_MESSAGE_APPLY;
+	public static String EditAgentSection_MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND;
+	public static String PresetsTab_TITLE;
+	public static String BaseWizardPage_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED;
+	public static String StartAgentWizard_MESSAGE_FAILED_TO_START_AGENT;
+	public static String StartAgentWizard_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR;
+	public static String StartAgentWizard_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED;
+	public static String StartAgentWizard_MESSAGE_INVALID_AGENT_CONFIG;
+	public static String StartAgentWizard_MESSAGE_ACCESS_TO_UNSAFE_REQUIRED;
+	public static String StartAgentWizardPage_PAGE_NAME;
+	public static String StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_TITLE;
+	public static String StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION;
+	public static String StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_JAR;
+	public static String StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_CONFIG;
+	public static String StartAgentWizardPage_LABEL_TARGET_JVM;
+	public static String StartAgentWizardPage_LABEL_AGENT_JAR;
+	public static String StartAgentWizardPage_LABEL_AGENT_XML;
+	public static String StartAgentWizardPage_LABEL_BROWSE;
+	public static String StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_JAR;
+	public static String StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_CONFIG;
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+	}
+}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/editor/EditorTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/editor/EditorTab.java
@@ -7,16 +7,16 @@ import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
 
 public class EditorTab extends AgentFormPage {
-	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.editor.EditorTab";
-	private static final String TITLE = "Editor";
+	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.editor.EditorTab"; //$NON-NLS-1$
 
 	@Inject
 	public EditorTab(AgentEditor editor) {
-		super(editor, ID, TITLE);
+		super(editor, ID, Messages.EditorTab_TITLE);
 		// TODO Auto-generated constructor stub
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/ActionButtons.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/ActionButtons.java
@@ -63,6 +63,7 @@ import org.openjdk.jmc.console.ext.agent.AgentPlugin;
 import org.openjdk.jmc.console.ext.agent.manager.model.IPreset;
 import org.openjdk.jmc.console.ext.agent.manager.model.PresetRepository;
 import org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ProbeValidator;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ValidationResult;
 import org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage;
@@ -73,14 +74,8 @@ import org.openjdk.jmc.ui.wizards.OnePageWizardDialog;
 import org.xml.sax.SAXException;
 
 public class ActionButtons extends Composite {
-	private static final String LABEL_SAVE_TO_PRESET_BUTTON = "Save to Preset";
-	private static final String LABEL_SAVE_TO_FILE_BUTTON = "Save to File";
-	private static final String LABEL_APPLY_PRESET_BUTTON = "Apply Preset";
-	private static final String LABEL_APPLY_LOCAL_CONFIG_BUTTON = "Apply Local Config";
-	private static final String ERROR_PAGE_TITLE = "Error in Configuration";
 	private static final String FILE_OPEN_FILTER_PATH = "file.open.filter.path"; // $NON-NLS-1$
 	private static final String PRESET_XML_EXTENSION = "*.xml"; // $NON-NLS-1$
-	private static final String MESSAGE_APPLY_LOCAL_CONFIG = "Apply a local configuration";
 
 	private AgentJmxHelper helper;
 	private PresetRepository repository;
@@ -109,10 +104,10 @@ public class ActionButtons extends Composite {
 	}
 
 	private void createButtons(Composite parent) {
-		saveToPresetButton = createButton(parent, LABEL_SAVE_TO_PRESET_BUTTON);
-		saveToFileButton = createButton(parent, LABEL_SAVE_TO_FILE_BUTTON);
-		applyPresetButton = createButton(parent, LABEL_APPLY_PRESET_BUTTON);
-		applyLocalConfigButton = createButton(parent, LABEL_APPLY_LOCAL_CONFIG_BUTTON);
+		saveToPresetButton = createButton(parent, Messages.ActionButtons_LABEL_SAVE_TO_PRESET_BUTTON);
+		saveToFileButton = createButton(parent, Messages.ActionButtons_LABEL_SAVE_TO_FILE_BUTTON);
+		applyPresetButton = createButton(parent, Messages.ActionButtons_LABEL_APPLY_PRESET_BUTTON);
+		applyLocalConfigButton = createButton(parent, Messages.ActionButtons_LABEL_APPLY_LOCAL_CONFIG_BUTTON);
 	}
 
 	private final Button createButton(Composite parent, String text) {
@@ -161,8 +156,8 @@ public class ActionButtons extends Composite {
 	}
 
 	private void onApplyLocalConfig() {
-		String[] path = openFileDialog(MESSAGE_APPLY_LOCAL_CONFIG, new String[] {PRESET_XML_EXTENSION},
-				SWT.OPEN | SWT.SINGLE);
+		String[] path = openFileDialog(Messages.ActionButtons_MESSAGE_APPLY_LOCAL_CONFIG,
+				new String[] {PRESET_XML_EXTENSION}, SWT.OPEN | SWT.SINGLE);
 		if (path != null && path.length != 0) {
 			applyConfig(path[0]);
 		}
@@ -298,7 +293,7 @@ public class ActionButtons extends Composite {
 			byte[] bytes = Files.readAllBytes(Paths.get(path));
 			String validationMessage = validateProbeDefinition(new String(bytes, StandardCharsets.UTF_8));
 			if (!validationMessage.isEmpty()) {
-				DialogToolkit.openConfirmOnUiThread(ERROR_PAGE_TITLE, validationMessage);
+				DialogToolkit.openConfirmOnUiThread(Messages.ActionButtons_ERROR_PAGE_TITLE, validationMessage);
 				return;
 			}
 			helper.defineEventProbes(new String(bytes, StandardCharsets.UTF_8));

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/EventTreeSection.java
@@ -63,7 +63,7 @@ import org.openjdk.jmc.ui.misc.MCSectionPart;
 import org.openjdk.jmc.ui.misc.TreeStructureContentProvider;
 
 public class EventTreeSection extends MCSectionPart {
-	private static final String EVENTS_TREE_NAME = "AgentUi.EventsTree";
+	private static final String EVENTS_TREE_NAME = "AgentUi.EventsTree"; //$NON-NLS-1$
 
 	private final TreeViewer viewer;
 	private AgentJmxHelper agentJmxHelper;

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/LiveConfigTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/liveconfig/LiveConfigTab.java
@@ -48,12 +48,12 @@ import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
 import org.openjdk.jmc.console.ext.agent.manager.model.PresetRepository;
 import org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
 
 public class LiveConfigTab extends AgentFormPage {
-	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.liveconfig.LiveConfigTab";
-	private static final String TITLE = "Live Config";
+	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.liveconfig.LiveConfigTab"; //$NON-NLS-1$
 
 	private SashForm sashForm;
 	private EventTreeSection eventTree;
@@ -61,7 +61,7 @@ public class LiveConfigTab extends AgentFormPage {
 	private final PresetRepository presetRepository = PresetRepositoryFactory.createSingleton();
 
 	public LiveConfigTab(AgentEditor editor) {
-		super(editor, ID, TITLE);
+		super(editor, ID, Messages.LiveConfigTab_TITLE);
 	}
 
 	@Inject

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/overview/OverviewTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/overview/OverviewTab.java
@@ -14,6 +14,7 @@ import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
 
@@ -21,14 +22,13 @@ import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;
 
 public class OverviewTab extends AgentFormPage {
-	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab";
-	private static final String TITLE = "Overview";
+	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.overview.OverviewTab"; //$NON-NLS-1$
 	private VirtualMachine vm;
 	private AgentJmxHelper agentJMXHelper;
 	private Composite container;
 
 	public OverviewTab(AgentEditor editor) {
-		super(editor, ID, TITLE);
+		super(editor, ID, Messages.OverviewTab_TITLE);
 		// TODO Auto-generated constructor stub
 	}
 
@@ -42,12 +42,12 @@ public class OverviewTab extends AgentFormPage {
 		container.setLayout(MCLayoutFactory.createFormPageLayout());
 
 		Label l = new Label(container, SWT.NONE);
-		l.setText("Agent is loaded");
+		l.setText(Messages.OverviewTab_MESSAGE_AGENT_LOADED);
 	}
 
 	private void loadAgentListener() {
 		Label l = new Label(container, SWT.NONE);
-		l.setText("Agent is loaded");
+		l.setText(Messages.OverviewTab_MESSAGE_AGENT_LOADED);
 		container.layout();
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/EditAgentSection.java
@@ -26,6 +26,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.AgentPlugin;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlEditor;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ProbeValidator;
 import org.openjdk.jmc.console.ext.agent.tabs.presets.internal.ValidationResult;
@@ -33,13 +34,6 @@ import org.openjdk.jmc.ui.MCPathEditorInput;
 import org.xml.sax.SAXException;
 
 public class EditAgentSection extends Composite {
-	private static final String MESSAGE_ENTER_PATH = "Enter Path...";
-	private static final String MESSAGE_AGENT_XML_PATH = "XML Path: ";
-	private static final String MESSAGE_BROWSE = "Browse";
-	private static final String MESSAGE_EDIT = "Edit";
-	private static final String MESSAGE_VALIDATE = "Validate";
-	private static final String MESSAGE_APPLY = "Apply";
-	private static final String MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND = "No errors/warnings found!";
 
 	private AgentJmxHelper agentJmxHelper = null;
 	final private Text messageOutput;
@@ -57,15 +51,15 @@ public class EditAgentSection extends Composite {
 			gridData.widthHint = 100;
 
 			Label label = new Label(row, SWT.NONE);
-			label.setText(MESSAGE_AGENT_XML_PATH);
+			label.setText(Messages.EditAgentSection_MESSAGE_AGENT_XML_PATH);
 			label.setLayoutData(gridData);
 
 			Text text = new Text(row, SWT.LEFT | SWT.BORDER);
 			text.setLayoutData(gridData);
-			text.setText(MESSAGE_ENTER_PATH);
+			text.setText(Messages.EditAgentSection_MESSAGE_ENTER_PATH);
 
 			Button browse = new Button(row, SWT.PUSH);
-			browse.setText(MESSAGE_BROWSE);
+			browse.setText(Messages.EditAgentSection_MESSAGE_BROWSE);
 			browse.setLayoutData(gridData);
 			browse.addListener(SWT.Selection, e -> {
 				FileDialog fd = new FileDialog(Display.getCurrent().getActiveShell());
@@ -80,7 +74,7 @@ public class EditAgentSection extends Composite {
 			row.setLayout(new GridLayout(3, false));
 
 			Button edit = new Button(row, SWT.PUSH);
-			edit.setText(MESSAGE_EDIT);
+			edit.setText(Messages.EditAgentSection_MESSAGE_EDIT);
 			edit.setLayoutData(gridData);
 			edit.addListener(SWT.Selection, event -> {
 				IEditorInput input = new MCPathEditorInput(new File(text.getText()), false);
@@ -94,7 +88,7 @@ public class EditAgentSection extends Composite {
 			});
 
 			Button validate = new Button(row, SWT.PUSH);
-			validate.setText(MESSAGE_VALIDATE);
+			validate.setText(Messages.EditAgentSection_MESSAGE_VALIDATE);
 			validate.setLayoutData(gridData);
 			validate.addListener(SWT.Selection, event -> {
 				try {
@@ -106,7 +100,7 @@ public class EditAgentSection extends Composite {
 			});
 
 			Button apply = new Button(row, SWT.PUSH);
-			apply.setText(MESSAGE_APPLY);
+			apply.setText(Messages.EditAgentSection_MESSAGE_APPLY);
 			apply.setLayoutData(gridData);
 			apply.addListener(SWT.Selection, event -> {
 				try {
@@ -172,7 +166,7 @@ public class EditAgentSection extends Composite {
 
 		String message = sb.toString();
 		if (message.isEmpty()) {
-			message = MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND;
+			message = Messages.EditAgentSection_MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND;
 		}
 
 		messageOutput.setText(message);

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/PresetsTab.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/tabs/presets/PresetsTab.java
@@ -9,17 +9,17 @@ import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentFormPage;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.ui.misc.MCLayoutFactory;
 
 public class PresetsTab extends AgentFormPage {
-	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.presets.PresetsTab";
-	private static final String TITLE = "Presets";
+	private static final String ID = "org.openjdk.jmc.console.ext.agent.tabs.presets.PresetsTab"; //$NON-NLS-1$
 
 	private EditAgentSection editAgentSection;
 
 	public PresetsTab(AgentEditor editor) {
-		super(editor, ID, TITLE);
+		super(editor, ID, Messages.PresetsTab_TITLE);
 		// TODO Auto-generated constructor stub
 	}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/BaseWizardPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/BaseWizardPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI;
 import org.openjdk.jmc.ui.column.ColumnBuilder;
 import org.openjdk.jmc.ui.column.ColumnManager;
@@ -39,8 +40,6 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class BaseWizardPage extends WizardPage {
-
-	private static final String MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED = "An unexpected has error occurred.";
 
 	private static final String FILE_OPEN_FILTER_PATH = "file.open.filter.path"; // $NON-NLS-1$
 
@@ -209,7 +208,8 @@ public abstract class BaseWizardPage extends WizardPage {
 			setErrorMessage(e.getLocalizedMessage());
 		} catch (Exception e) {
 			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-			DialogToolkit.showException(window.getShell(), MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
+			DialogToolkit.showException(window.getShell(),
+					Messages.BaseWizardPage_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
 		}
 
 		setPageComplete(exceptions.isEmpty());

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizard.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizard.java
@@ -45,6 +45,7 @@ import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditor;
 import org.openjdk.jmc.console.ext.agent.editor.AgentEditorInput;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.ui.common.jvm.JVMDescriptor;
 import org.openjdk.jmc.ui.misc.DialogToolkit;
 
@@ -53,11 +54,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class StartAgentWizard extends Wizard {
-	private static final String MESSAGE_FAILED_TO_START_AGENT = "Failed to start JMC Agent";
-	private static final String MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR = "Failed to open the JMC Agent Editor";
-	private static final String MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED = "An unexpected has error occurred.";
-	private static final String MESSAGE_INVALID_AGENT_CONFIG = "An invalid configuration is entered.";
-	private static final String MESSAGE_ACCESS_TO_UNSAFE_REQUIRED = "Could not access jdk.internal.misc.Unsafe! Did you run your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'?";
 
 	private final AgentJmxHelper helper;
 	private final StartAgentWizardPage startAgentWizardPage;
@@ -85,20 +81,21 @@ public class StartAgentWizard extends Wizard {
 			IEditorInput ei = new AgentEditorInput(helper.getServerHandle(), helper.getConnectionHandle(), helper);
 			window.getActivePage().openEditor(ei, AgentEditor.EDITOR_ID, true);
 		} catch (IllegalArgumentException e) {
-			DialogToolkit.showException(window.getShell(), MESSAGE_FAILED_TO_START_AGENT, MESSAGE_INVALID_AGENT_CONFIG,
-					e);
+			DialogToolkit.showException(window.getShell(), Messages.StartAgentWizard_MESSAGE_FAILED_TO_START_AGENT,
+					Messages.StartAgentWizard_MESSAGE_INVALID_AGENT_CONFIG, e);
 			return false;
 		} catch (AttachNotSupportedException | IOException | AgentLoadException e) {
-			DialogToolkit.showException(window.getShell(), MESSAGE_FAILED_TO_START_AGENT,
-					MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
+			DialogToolkit.showException(window.getShell(), Messages.StartAgentWizard_MESSAGE_FAILED_TO_START_AGENT,
+					Messages.StartAgentWizard_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
 			return false;
 		} catch (AgentInitializationException e) {
-			DialogToolkit.showException(window.getShell(), MESSAGE_FAILED_TO_START_AGENT,
-					MESSAGE_ACCESS_TO_UNSAFE_REQUIRED, e);
+			DialogToolkit.showException(window.getShell(), Messages.StartAgentWizard_MESSAGE_FAILED_TO_START_AGENT,
+					Messages.StartAgentWizard_MESSAGE_ACCESS_TO_UNSAFE_REQUIRED, e);
 			return false;
 		} catch (PartInitException e) {
-			DialogToolkit.showException(window.getShell(), MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR,
-					MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
+			DialogToolkit.showException(window.getShell(),
+					Messages.StartAgentWizard_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR,
+					Messages.StartAgentWizard_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED, e);
 			return false;
 		}
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizardPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizardPage.java
@@ -41,22 +41,10 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.console.ext.agent.AgentJmxHelper;
+import org.openjdk.jmc.console.ext.agent.messages.internal.Messages;
 import org.openjdk.jmc.ui.common.jvm.JVMDescriptor;
 
 public class StartAgentWizardPage extends BaseWizardPage {
-	private static final String PAGE_NAME = "Start Agent Wizard Page";
-	private static final String MESSAGE_START_AGENT_WIZARD_PAGE_TITLE = "Start JMC Agent";
-	private static final String MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION = "Enter the JMC Agent configuration details and then click Finish to start the agent.";
-	private static final String MESSAGE_PATH_TO_AN_AGENT_JAR = "Path to an agent JAR";
-	private static final String MESSAGE_PATH_TO_AN_AGENT_CONFIG = "(Optional) Path to an agent configuration";
-
-	private static final String LABEL_TARGET_JVM = "Target JVM: ";
-	private static final String LABEL_AGENT_JAR = "Agent JAR: ";
-	private static final String LABEL_AGENT_XML = "Agent XML: ";
-	private static final String LABEL_BROWSE = "Browse...";
-
-	private static final String DIALOG_BROWSER_FOR_AGENT_JAR = "Browser for JMC Agent JAR";
-	private static final String DIALOG_BROWSER_FOR_AGENT_CONFIG = "Browser for JMC Agent Configuration";
 
 	private static final String FILE_OPEN_JAR_EXTENSION = "*.jar"; // $NON-NLS-1$
 	private static final String FILE_OPEN_XML_EXTENSION = "*.xml"; // $NON-NLS-1$
@@ -70,7 +58,7 @@ public class StartAgentWizardPage extends BaseWizardPage {
 	private Button agentXmlBrowseButton;
 
 	protected StartAgentWizardPage(AgentJmxHelper helper) {
-		super(PAGE_NAME);
+		super(Messages.StartAgentWizardPage_PAGE_NAME);
 
 		this.helper = helper;
 	}
@@ -79,8 +67,8 @@ public class StartAgentWizardPage extends BaseWizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		setTitle(MESSAGE_START_AGENT_WIZARD_PAGE_TITLE);
-		setDescription(MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION);
+		setTitle(Messages.StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_TITLE);
+		setDescription(Messages.StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION);
 
 		ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
 		Composite container = new Composite(sc, SWT.NONE);
@@ -121,7 +109,7 @@ public class StartAgentWizardPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		targetJvmText = createTextInput(container, cols, LABEL_TARGET_JVM, ""); // $NON-NLS-1$
+		targetJvmText = createTextInput(container, cols, Messages.StartAgentWizardPage_LABEL_TARGET_JVM, ""); // $NON-NLS-1$
 		targetJvmText.setEnabled(false);
 
 		return container;
@@ -134,14 +122,16 @@ public class StartAgentWizardPage extends BaseWizardPage {
 		layout.horizontalSpacing = 8;
 		container.setLayout(layout);
 
-		agentJarText = createTextInput(container, cols - 2, LABEL_AGENT_JAR, MESSAGE_PATH_TO_AN_AGENT_JAR);
+		agentJarText = createTextInput(container, cols - 2, Messages.StartAgentWizardPage_LABEL_AGENT_JAR,
+				Messages.StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_JAR);
 		agentJarText.setEditable(false);
-		agentJarBrowseButton = createButton(container, LABEL_BROWSE);
+		agentJarBrowseButton = createButton(container, Messages.StartAgentWizardPage_LABEL_BROWSE);
 		agentJarBrowseButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 0));
 
-		agentXmlText = createTextInput(container, cols - 2, LABEL_AGENT_XML, MESSAGE_PATH_TO_AN_AGENT_CONFIG);
+		agentXmlText = createTextInput(container, cols - 2, Messages.StartAgentWizardPage_LABEL_AGENT_XML,
+				Messages.StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_CONFIG);
 		agentXmlText.setEditable(false);
-		agentXmlBrowseButton = createButton(container, LABEL_BROWSE);
+		agentXmlBrowseButton = createButton(container, Messages.StartAgentWizardPage_LABEL_BROWSE);
 		agentXmlBrowseButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 0));
 
 		return container;
@@ -149,15 +139,15 @@ public class StartAgentWizardPage extends BaseWizardPage {
 
 	private void bindListeners() {
 		agentJarBrowseButton.addListener(SWT.Selection, e -> {
-			String[] path = openFileDialog(DIALOG_BROWSER_FOR_AGENT_JAR, new String[] {FILE_OPEN_JAR_EXTENSION},
-					SWT.OPEN | SWT.SINGLE);
+			String[] path = openFileDialog(Messages.StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_JAR,
+					new String[] {FILE_OPEN_JAR_EXTENSION}, SWT.OPEN | SWT.SINGLE);
 			if (path != null && path.length != 0) {
 				setText(agentJarText, path[0]);
 			}
 		});
 		agentXmlBrowseButton.addListener(SWT.Selection, e -> {
-			String[] path = openFileDialog(DIALOG_BROWSER_FOR_AGENT_CONFIG, new String[] {FILE_OPEN_XML_EXTENSION},
-					SWT.OPEN | SWT.SINGLE);
+			String[] path = openFileDialog(Messages.StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_CONFIG,
+					new String[] {FILE_OPEN_XML_EXTENSION}, SWT.OPEN | SWT.SINGLE);
 			if (path != null && path.length != 0) {
 				setText(agentXmlText, path[0]);
 			}

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
@@ -1,0 +1,195 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, Red Hat Inc. All rights reserved.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The contents of this file are subject to the terms of either the Universal Permissive License
+# v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#
+# or the following license:
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+# and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials provided with
+# the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+# endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+# WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+AgentEditorOpener_JOB_NAME=Connecting to RJMX service
+AgentEditorOpener_MESSAGE_COULD_NOT_CONNECT=Could not connect
+AgentEditorOpener_MESSAGE_STARTING_AGENT_ON_REMOTE_JVM_NOT_SUPPORTED=Starting an agent on remote JVM is not supported
+AgentEditorOpener_MESSAGE_START_AGENT_MANUALLY=Start the agent manually and try again
+AgentEditorOpener_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR=Failed to open the JMC Agent Editor
+
+AgendEditor_CONNECTION_LOST=Connection Lost
+AgendEditor_COULD_NOT_CONNECT=Could not connect
+
+CapturedValue_ERROR_RELATION_KEY_HAS_INCORRECT_SYNTAX=Relation key has incorrect syntax.
+CapturedValue_ERROR_CONVERTER_HAS_INCORRECT_SYNTAX=Converter has incorrect syntax.
+
+Event_ERROR_ID_CANNOT_BE_EMPTY_OR_NULL=ID cannot be empty or null.
+Event_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
+Event_ERROR_CLASS_CANNOT_BE_EMPTY_OR_NULL=Class cannot be empty or null.
+Event_ERROR_METHOD_NAME_CANNOT_BE_EMPTY_OR_NULL=Method name cannot be empty or null.
+Event_ERROR_METHOD_DESCRIPTOR_CANNOT_BE_EMPTY_OR_NULL=Method descriptor cannot be empty or null.
+Event_ERROR_METHOD_PARAMETER_CANNOT_BE_NULL=Method parameter cannot be null.
+Event_ERROR_FIELD_CANNOT_BE_NULL=Field cannot be null.
+Event_ERROR_CLASS_HAS_INCORRECT_SYNTAX=Class has incorrect syntax.
+Event_ERROR_PATH_HAS_INCORRECT_SYNTAX=Path has incorrect syntax.
+Event_ERROR_METHOD_NAME_HAS_INCORRECT_SYNTAX=Method name has incorrect syntax.
+Event_ERROR_METHOD_DESCRIPTOR_HAS_INCORRECT_SYNTAX=Method descriptor has incorrect syntax.
+Event_ERROR_INDEX_MUST_BE_UNIQUE=Method parameter index must be unique.
+
+Field_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
+Field_ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL=Expression cannot be empty or null.
+Field_ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX=Expression has incorrect syntax.
+
+MethodParameterERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO=Index cannot be less than zero.
+MethodParameterERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
+
+Preset_ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL=File name cannot be empty or null.
+Preset_ERROR_MUST_HAVE_UNIQUE_ID=An event with the same id already exists.
+Preset_ERROR_MUST_HAVE_UNIQUE_EVENT_CLASS_NAME=Event must have a unique event name per class
+
+CapturedValueEditingPage_PAGE_NAME=Agent Captured Value Editing
+CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_TITLE=Edit a Parameter or Return Value
+CapturedValueEditingPage_MESSAGE_PARAMETER_OR_RETURN_VALUE_EDITING_PAGE_DESCRIPTION=Define a capturing of a method parameter or a return value.
+CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_TITLE=Edit a Parameter or Return Value Capturing
+CapturedValueEditingPage_MESSAGE_FIELD_EDITING_PAGE_DESCRIPTION=Define a custom expression evaluation and capture its result.
+CapturedValueEditingPage_LABEL_NAME=Name: 
+CapturedValueEditingPage_LABEL_INDEX=Index: 
+CapturedValueEditingPage_LABEL_IS_RETURN_VALUE=This is a return value
+CapturedValueEditingPage_LABEL_EXPRESSION=Expression: 
+CapturedValueEditingPage_LABEL_DESCRIPTION=Description: 
+CapturedValueEditingPage_LABEL_CONTENT_TYPE=Content Type: 
+CapturedValueEditingPage_LABEL_CLEAR=Clear
+CapturedValueEditingPage_LABEL_RELATIONAL_KEY=Relational Key: 
+CapturedValueEditingPage_LABEL_CONVERTER=Converter: 
+CapturedValueEditingPage_MESSAGE_NAME_OF_THE_CAPTURING=Name of this capturing
+CapturedValueEditingPage_MESSAGE_JAVA_PRIMARY_EXPRESSION_TO_BE_EVALUATED=Java primary expression to be evaluated
+CapturedValueEditingPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_CAPTURING=(Optional) Description of this capturing
+CapturedValueEditingPage_MESSAGE_RELATIONAL_KEY_DESCRIPTION=(Optional) Unique URI signifying a relationship
+CapturedValueEditingPage_MESSAGE_CONVERTER_DESCRIPTION=(Optional) fully qualified class name of a value converter
+
+EventEditingWizardConfigPage_PAGE_NAME=Agent Event Editing
+EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_TITLE=Edit Event Configurations
+EventEditingWizardConfigPage_MESSAGE_EVENT_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION=Edit basic information of an event on how it should be instrumented and injected.
+EventEditingWizardConfigPage_LABEL_ID=ID: 
+EventEditingWizardConfigPage_LABEL_NAME=Name: 
+EventEditingWizardConfigPage_LABEL_DESCRIPTION=Description: 
+EventEditingWizardConfigPage_LABEL_CLASS=Class: 
+EventEditingWizardConfigPage_LABEL_METHOD=Method: 
+EventEditingWizardConfigPage_LABEL_PATH=Path: 
+EventEditingWizardConfigPage_LABEL_LOCATION=Location: 
+EventEditingWizardConfigPage_LABEL_CLEAR=Clear
+EventEditingWizardConfigPage_LABEL_RECORD_EXCEPTIONS=Record exceptions
+EventEditingWizardConfigPage_LABEL_RECORD_STACK_TRACE=Record stack trace
+EventEditingWizardConfigPage_MESSAGE_EVENT_ID=Event ID
+EventEditingWizardConfigPage_MESSAGE_NAME_OF_THE_EVENT=Name of the event
+EventEditingWizardConfigPage_MESSAGE_FULLY_QUALIFIED_CLASS_NAME=Fully qualified class name
+EventEditingWizardConfigPage_MESSAGE_METHOD_NAME=Method name
+EventEditingWizardConfigPage_MESSAGE_METHOD_DESCRIPTOR=Method descriptor
+EventEditingWizardConfigPage_MESSAGE_OPTIONAL_DESCRIPTION_OF_THIS_EVENT=(Optional) Description of this event
+EventEditingWizardConfigPage_MESSAGE_PATH_TO_EVENT=Path to event in event browser
+
+EventEditingWizardFieldPage_PAGE_NAME=Agent Event Editing
+EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_TITLE=Add or Remove Event Fields
+EventEditingWizardFieldPage_MESSAGE_EVENT_EDITING_WIZARD_FIELD_PAGE_DESCRIPTION=Fields are a subset of Java primary expressions which can be evaluated and recorded when committing an event.
+EventEditingWizardFieldPage_MESSAGE_UNABLE_TO_SAVE_THE_FIELD=Unable to add the field
+EventEditingWizardFieldPage_LABEL_NAME=Name
+EventEditingWizardFieldPage_LABEL_EXPRESSION=Expression
+EventEditingWizardFieldPage_LABEL_DESCRIPTION=Description
+EventEditingWizardFieldPage_ID_NAME=name
+EventEditingWizardFieldPage_ID_EXPRESSION=expression
+EventEditingWizardFieldPage_ID_DESCRIPTION=description
+
+EventEditingWizardParameterPage_PAGE_NAME=Agent Event Editing
+EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_TITLE=Add or Remove Event Parameters
+EventEditingWizardParameterPage_MESSAGE_EVENT_EDITING_WIZARD_PARAMETER_PAGE_DESCRIPTION=Function parameters and return values can be recorded when committing an event.
+EventEditingWizardParameterPage_MESSAGE_RETURN_VALUE=(Return value)
+EventEditingWizardParameterPage_MESSAGE_UNABLE_TO_SAVE_THE_PARAMETER_OR_RETURN_VALUE=Unable to add the parameter/return value
+EventEditingWizardParameterPage_LABEL_INDEX=Index
+EventEditingWizardParameterPage_LABEL_NAME=Name
+EventEditingWizardParameterPage_LABEL_DESCRIPTION=Description
+EventEditingWizardParameterPage_ID_INDEX=index
+EventEditingWizardParameterPage_ID_NAME=name
+EventEditingWizardParameterPage_ID_DESCRIPTION=description
+
+PresetEditingWizardConfigPage_PAGE_NAME=Agent Preset Editing
+PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_TITLE=Edit Preset Global Configurations
+PresetEditingWizardConfigPage_MESSAGE_PRESET_EDITING_WIZARD_CONFIG_PAGE_DESCRIPTION=Global configurations are defaults which applies to any event missing a per-even configuration.
+PresetEditingWizardConfigPage_LABEL_FILE_NAME=File Name: 
+PresetEditingWizardConfigPage_LABEL_CLASS_PREFIX=Class Prefix: 
+PresetEditingWizardConfigPage_LABEL_ALLOW_TO_STRING=Allow toString
+PresetEditingWizardConfigPage_LABEL_ALLOW_CONVERTER=Allow Converter
+PresetEditingWizardConfigPage_MESSAGE_NAME_OF_THE_SAVED_XML=Name of the saved XML on file system
+PresetEditingWizardConfigPage_MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES=Prefix added to generated event classes
+
+PresetManagerPage_PAGE_NAME=Agent Preset Manager
+PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_TITLE=JMC Agent Configuration Preset Manager
+PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_DESCRIPTION=Presets for JMC agent are useful to repeatedly apply configurations to a running JMC agent.
+PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_SAVE_THE_PRESET=Unable to save the preset
+PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_IMPORT_THE_PRESET=Unable to import the preset
+PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET=Unable to export the preset
+PresetManagerPage_MESSAGE_IMPORT_EXTERNAL_PRESET_FILES=Import external preset files
+PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE=Import the preset to a file
+PresetManagerPage_MESSAGE_EVENTS=event(s)
+
+EditorTab_TITLE=Editor
+
+ActionButtons_LABEL_SAVE_TO_PRESET_BUTTON=Save to Preset
+ActionButtons_LABEL_SAVE_TO_FILE_BUTTON=Save to File
+ActionButtons_LABEL_APPLY_PRESET_BUTTON=Apply Preset
+ActionButtons_LABEL_APPLY_LOCAL_CONFIG_BUTTON=Apply Local Config
+ActionButtons_ERROR_PAGE_TITLE=Error in Configuration
+ActionButtons_MESSAGE_APPLY_LOCAL_CONFIG=Apply a local configuration
+
+LiveConfigTab_TITLE=Live Config
+
+OverviewTab_TITLE=Overview
+OverviewTab_MESSAGE_AGENT_LOADED=Agent is loaded
+
+EditAgentSection_MESSAGE_ENTER_PATH=Enter Path...
+EditAgentSection_MESSAGE_AGENT_XML_PATH=XML Path: 
+EditAgentSection_MESSAGE_BROWSE=Browse
+EditAgentSection_MESSAGE_EDIT=Edit
+EditAgentSection_MESSAGE_VALIDATE=Validate
+EditAgentSection_MESSAGE_APPLY=Apply
+EditAgentSection_MESSAGE_NO_WARNINGS_OR_ERRORS_FOUND=No errors/warnings found!
+
+PresetsTab_TITLE=Presets
+
+BaseWizardPage_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED=An unexpected has error occurred.
+
+StartAgentWizard_MESSAGE_FAILED_TO_START_AGENT=Failed to start JMC Agent
+StartAgentWizard_MESSAGE_FAILED_TO_OPEN_AGENT_EDITOR=Failed to open the JMC Agent Editor
+StartAgentWizard_MESSAGE_UNEXPECTED_ERROR_HAS_OCCURRED=An unexpected has error occurred.
+StartAgentWizard_MESSAGE_INVALID_AGENT_CONFIG=An invalid configuration is entered.
+StartAgentWizard_MESSAGE_ACCESS_TO_UNSAFE_REQUIRED=Could not access jdk.internal.misc.Unsafe! Did you run your application with '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED'?
+StartAgentWizardPage_PAGE_NAME=Start Agent Wizard Page
+StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_TITLE=Start JMC Agent
+StartAgentWizardPage_MESSAGE_START_AGENT_WIZARD_PAGE_DESCRIPTION=Enter the JMC Agent configuration details and then click Finish to start the agent.
+StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_JAR=Path to an agent JAR
+StartAgentWizardPage_MESSAGE_PATH_TO_AN_AGENT_CONFIG=(Optional) Path to an agent configuration
+StartAgentWizardPage_LABEL_TARGET_JVM=Target JVM: 
+StartAgentWizardPage_LABEL_AGENT_JAR=Agent JAR: 
+StartAgentWizardPage_LABEL_AGENT_XML=Agent XML: 
+StartAgentWizardPage_LABEL_BROWSE=Browse...
+StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_JAR=Browser for JMC Agent JAR
+StartAgentWizardPage_DIALOG_BROWSER_FOR_AGENT_CONFIG=Browser for JMC Agent Configuration


### PR DESCRIPTION
This PR addresses issue https://github.com/rh-jmc-team/jmc-agent-plugin/issues/83, in which it would be nice if strings were externalized similar to how they are in JMC.

This approach introduces a `Messages.java` and `messages.properties` similar to JMC, and contains the strings used for the UI, messages, and error output.