### PR TITLE
Fix Typos in messages.properties, Fix agent probe definition format

### DIFF
--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
@@ -65,7 +65,7 @@ public class Event implements IEvent {
 	private static final Pattern COUNT_SUFFIX_PATTERN = Pattern.compile("^\\s*\\((\\d+)\\)$"); // $NON-NLS-1$
 
 	private static final String XML_TAG_EVENT = "event"; // $NON-NLS-1$
-	private static final String XML_TAG_NAME = "name"; // $NON-NLS-1$
+	private static final String XML_TAG_NAME = "label"; // $NON-NLS-1$
 	private static final String XML_TAG_DESCRIPTION = "description"; // $NON-NLS-1$
 	private static final String XML_TAG_CLASS = "class"; // $NON-NLS-1$
 	private static final String XML_TAG_PATH = "path"; // $NON-NLS-1$
@@ -80,6 +80,7 @@ public class Event implements IEvent {
 	private static final String XML_TAG_FIELD = "field"; // $NON-NLS-1$
 	private static final String XML_TAG_RETURN_VALUE = "returnvalue"; // $NON-NLS-1$
 	private static final String XML_ATTRIBUTE_ID = "id"; // $NON-NLS-1$
+	private static final String XML_TAG_METHOD_NAME = "name"; // $NON-NLS-1$
 
 	private final Preset preset;
 	private final List<IMethodParameter> parameters = new ArrayList<>();
@@ -145,7 +146,7 @@ public class Event implements IEvent {
 		}
 
 		Element methodElement = getFirstDirectChildElementByTagName(element, XML_TAG_METHOD);
-		methodName = getFirstDirectChildElementByTagName(methodElement, XML_TAG_NAME).getTextContent();
+		methodName = getFirstDirectChildElementByTagName(methodElement, XML_TAG_METHOD_NAME).getTextContent();
 		methodDescriptor = getFirstDirectChildElementByTagName(methodElement, XML_TAG_DESCRIPTOR).getTextContent();
 
 		Element parametersElement = getFirstDirectChildElementByTagName(methodElement, XML_TAG_PARAMETERS);
@@ -173,7 +174,7 @@ public class Event implements IEvent {
 	private Element buildMethodElement(Document document) {
 		Element methodElement = document.createElement(XML_TAG_METHOD);
 		{
-			Element methodNameElement = document.createElement(XML_TAG_NAME);
+			Element methodNameElement = document.createElement(XML_TAG_METHOD_NAME);
 			methodNameElement.setTextContent(methodName);
 			methodElement.appendChild(methodNameElement);
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
@@ -60,8 +60,8 @@ Field_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
 Field_ERROR_EXPRESSION_CANNOT_BE_EMPTY_OR_NULL=Expression cannot be empty or null.
 Field_ERROR_EXPRESSION_HAS_INCORRECT_SYNTAX=Expression has incorrect syntax.
 
-MethodParameterERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO=Index cannot be less than zero.
-MethodParameterERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
+MethodParameter_ERROR_INDEX_CANNOT_BE_LESS_THAN_ZERO=Index cannot be less than zero.
+MethodParameter_ERROR_NAME_CANNOT_BE_EMPTY_OR_NULL=Name cannot be empty or null.
 
 Preset_ERROR_FILE_NAME_CANNOT_BE_EMPTY_OR_NULL=File name cannot be empty or null.
 Preset_ERROR_MUST_HAVE_UNIQUE_ID=An event with the same id already exists.
@@ -140,6 +140,15 @@ PresetEditingWizardConfigPage_LABEL_ALLOW_TO_STRING=Allow toString
 PresetEditingWizardConfigPage_LABEL_ALLOW_CONVERTER=Allow Converter
 PresetEditingWizardConfigPage_MESSAGE_NAME_OF_THE_SAVED_XML=Name of the saved XML on file system
 PresetEditingWizardConfigPage_MESSAGE_PREFIX_ADDED_TO_GENERATED_EVENT_CLASSES=Prefix added to generated event classes
+	
+PresetEditingWizardEventPage_PAGE_NAME=Agent Preset Editing
+PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_TITLE=Add or Remove Preset Events
+PresetEditingWizardEventPage_MESSAGE_PRESET_EDITING_WIZARD_EVENT_PAGE_DESCRIPTION=Add new events to the prset, or remove/edit existing events.
+PresetEditingWizardEventPage_MESSAGE_UNABLE_TO_SAVE_THE_PRESET=Unable to add the event
+PresetEditingWizardEventPage_LABEL_ID_COLUMN=ID
+PresetEditingWizardEventPage_LABEL_NAME_COLUMN=name
+PresetEditingWizardEventPage_ID_ID_COLUMN=id
+PresetEditingWizardEventPage_ID_NAME_COLUMN=name
 
 PresetManagerPage_PAGE_NAME=Agent Preset Manager
 PresetManagerPage_MESSAGE_PRESET_MANAGER_PAGE_TITLE=JMC Agent Configuration Preset Manager
@@ -150,6 +159,10 @@ PresetManagerPage_MESSAGE_PRESET_MANAGER_UNABLE_TO_EXPORT_THE_PRESET=Unable to e
 PresetManagerPage_MESSAGE_IMPORT_EXTERNAL_PRESET_FILES=Import external preset files
 PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE=Import the preset to a file
 PresetManagerPage_MESSAGE_EVENTS=event(s)
+
+PresetEditingWizardPreviewPage_PAGE_NAME=Agent Preset Editing
+PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_TITLE=Preview Preset Output
+PresetEditingWizardPreviewPage_MESSAGE_PRESET_EDITING_WIZARD_PREVIEW_PAGE_DESCRIPTION=Inpsects the generated XML before it is saved. Click Back to make any modifications if needed. Click Finish to save.
 
 EditorTab_TITLE=Editor
 

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/utils/jfrprobes_schema.xsd
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/utils/jfrprobes_schema.xsd
@@ -47,7 +47,7 @@
 
 	<xs:complexType name="eventType">
 		<xs:all>
-			<xs:element type="xs:string" name="name" />
+			<xs:element type="xs:string" name="label" />
 			<xs:element type="classType" name="class" />
 			<xs:element type="methodType" name="method" />
 			<xs:element type="xs:string" name="description" minOccurs="0" />


### PR DESCRIPTION
Hi,

This PR fixes a few typos and missing localization strings and brings the generated probe definitions in line with what the agent now expects.