### PR TITLE
Copyright update

### DIFF
--- a/configuration/spotbugs/spotbugs-exclude.xml
+++ b/configuration/spotbugs/spotbugs-exclude.xml
@@ -44,10 +44,6 @@
 		<Bug pattern="REC_CATCH_EXCEPTION"/>
 	</Match>
 	<Match>
-		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorBak"/>
-		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-	</Match>
-	<Match>
 		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi"/>
 		<Method name="refresh"/>
 		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
@@ -88,6 +84,21 @@
 		<Bug pattern="UUF_UNUSED_FIELD"/>
 	</Match>
 	<Match>
+		<Class name="org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage" />
+		<Method name="openFileDialog"/>
+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+	</Match>
+	<Match>
+		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
+		<Method name="createSingleton"/>
+		<Bug pattern="DC_DOUBLECHECK" />
+	</Match>
+	<!-- This is a false positive. Eclipse handles initialization of critical components elsewhere -->
+    <Match>
+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
+    	<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
+    </Match>
+    	<Match>
 		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.NonRuleBasedDamagerRepairer"/>
 		<Method name="endOfLineOf"/>
 		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
@@ -107,13 +118,21 @@
 		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 	</Match>
 	<Match>
-		<Class name="org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage" />
-		<Method name="openFileDialog"/>
-		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorBak"/>
+		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 	</Match>
-	<Match>
-		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
-		<Method name="createSingleton"/>
-		<Bug pattern="DC_DOUBLECHECK" />
-	</Match>
+    <!-- There is a blanket exclude on these types of bugs in JMC.
+     in UI classes the memory overhead is minimal and reworking it isn't really worth it -->
+    <Match>
+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
+    <Match>
+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
+    <Match>
+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
+    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
 </FindBugsFilter>

--- a/org.openjdk.jmc.console.ext.agent/plugin.xml
+++ b/org.openjdk.jmc.console.ext.agent/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/org.openjdk.jmc.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.console.ext.agent/pom.xml
@@ -42,7 +42,7 @@
 		<!--artifactId>missioncontrol.application</artifactId-->
 		<!--TODO: replace this with above when merging to JMC repo-->
 		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.openjdk.jmc.console.ext.agent</artifactId>

--- a/org.openjdk.jmc.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.console.ext.agent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/org.openjdk.jmc.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.console.ext.agent/pom.xml
@@ -42,7 +42,7 @@
 		<!--artifactId>missioncontrol.application</artifactId-->
 		<!--TODO: replace this with above when merging to JMC repo-->
 		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.openjdk.jmc.console.ext.agent</artifactId>

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentJmxHelper.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentPlugin.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/AgentPlugin.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/actions/AgentEditorOpener.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditor.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorAction.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorAction.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorInput.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorInput.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorUi.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/AgentEditorUi.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/EventDetailSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/EventDetailSection.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/EventListSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/EventListSection.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/GlobalConfigSection.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/editor/sections/GlobalConfigSection.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/OpenPresetManagerHandler.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/OpenPresetManagerHandler.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/PresetManager.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/PresetManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/CapturedValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/CapturedValue.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Event.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Field.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Field.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/ICapturedValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/ICapturedValue.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IEvent.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IEvent.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IField.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IField.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodParameter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IMethodReturnValue.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IPreset.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IPreset.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IPresetStorageDelegate.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/IPresetStorageDelegate.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/LocalStorageDelegate.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/LocalStorageDelegate.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodParameter.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodParameter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodReturnValue.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/MethodReturnValue.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Preset.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/Preset.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepository.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepository.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/model/PresetRepositoryFactory.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/CapturedValueEditingPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/CapturedValueEditingPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizard.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizard.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardConfigPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardFieldPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/EventEditingWizardParameterPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizard.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizard.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardConfigPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardConfigPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardEventPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardEventPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardPreviewPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetEditingWizardPreviewPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetManagerPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/manager/wizards/PresetManagerPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/messages/internal/Messages.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/RawEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/RawEditor.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/ColorManager.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/ColorManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/NonRuleBasedDamagerRepairer.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/NonRuleBasedDamagerRepairer.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/TagRule.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/TagRule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlColorConstants.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlColorConstants.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlConfiguration.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlConfiguration.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDocumentProvider.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDocumentProvider.java
@@ -39,7 +39,7 @@ public class XmlDocumentProvider extends StorageDocumentProvider {
 		if (!out.exists()) {
 			try {
 				out.createNewFile();
-			} catch (IOException e) {
+			} catch (IOException | SecurityException e) {
 				IStatus s = new Status(IStatus.ERROR, EditorsUI.PLUGIN_ID, IStatus.OK, e.getMessage(), e);
 				throw new CoreException(s);
 			}

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDocumentProvider.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDocumentProvider.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDoubleClickStrategy.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlDoubleClickStrategy.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlEditor.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlEditor.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlPartitionScanner.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlPartitionScanner.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlScanner.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlScanner.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlTagScanner.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlTagScanner.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlWhitespaceDetector.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/raweditor/internal/XmlWhitespaceDetector.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/utils/ProbeValidator.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/utils/ProbeValidator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/utils/ValidationResult.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/utils/ValidationResult.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/BaseWizardPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/BaseWizardPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizard.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizard.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizardPage.java
+++ b/org.openjdk.jmc.console.ext.agent/src/main/java/org/openjdk/jmc/console/ext/agent/wizards/StartAgentWizardPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
+++ b/org.openjdk.jmc.console.ext.agent/src/main/resources/org/openjdk/jmc/console/ext/agent/messages/internal/messages.properties
@@ -1,6 +1,6 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2020, Red Hat Inc. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Red Hat Inc. All rights reserved.
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #

--- a/org.openjdk.jmc.feature.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.feature.console.ext.agent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/org.openjdk.jmc.feature.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.feature.console.ext.agent/pom.xml
@@ -40,7 +40,7 @@
 		<!--artifactId>missioncontrol.application</artifactId-->
 		<!--TODO: replace this with above when merging to JMC repo-->
 		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>org.openjdk.jmc.feature.console.ext.agent</artifactId>

--- a/org.openjdk.jmc.feature.console.ext.agent/pom.xml
+++ b/org.openjdk.jmc.feature.console.ext.agent/pom.xml
@@ -40,7 +40,7 @@
 		<!--artifactId>missioncontrol.application</artifactId-->
 		<!--TODO: replace this with above when merging to JMC repo-->
 		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>org.openjdk.jmc.feature.console.ext.agent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 	<parent>
 		<groupId>org.openjdk.jmc</groupId>
 		<artifactId>missioncontrol.application</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/application/org.openjdk.jmc.console.ext.agent/pom.xml b/application/org.openjdk.jmc.console.ext.agent/pom.xml
-index f4f39ff..d2b5d24 100644
+index 4f39161..d2b5d24 100644
 --- a/application/org.openjdk.jmc.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.console.ext.agent/pom.xml
 @@ -39,10 +39,8 @@
@@ -9,7 +9,7 @@ index f4f39ff..d2b5d24 100644
 -		<!--artifactId>missioncontrol.application</artifactId-->
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
--		<version>8.1.0-SNAPSHOT</version>
+-		<version>8.0.0-SNAPSHOT</version>
 +		<artifactId>missioncontrol.application</artifactId>
 +		<version>${revision}${changelist}</version>
  	</parent>
@@ -30,7 +30,7 @@ index f4f39ff..d2b5d24 100644
  
  	<build>
 diff --git a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
-index 4f9ae6e..b13eb10 100644
+index bb080eb..b13eb10 100644
 --- a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 @@ -37,10 +37,8 @@
@@ -40,7 +40,7 @@ index 4f9ae6e..b13eb10 100644
 -		<!--artifactId>missioncontrol.application</artifactId-->
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
--		<version>8.1.0-SNAPSHOT</version>
+-		<version>8.0.0-SNAPSHOT</version>
 +		<artifactId>missioncontrol.application</artifactId>
 +		<version>${revision}${changelist}</version>
  	</parent>
@@ -57,29 +57,29 @@ index 4f9ae6e..b13eb10 100644
  	</properties>
  </project>
 diff --git a/application/org.openjdk.jmc.feature.rcp/feature.xml b/application/org.openjdk.jmc.feature.rcp/feature.xml
-index ee1992f..bf35ec4 100644
+index ee1992f..7b00008 100644
 --- a/application/org.openjdk.jmc.feature.rcp/feature.xml
 +++ b/application/org.openjdk.jmc.feature.rcp/feature.xml
-@@ -71,6 +71,10 @@
-          id="org.openjdk.jmc.feature.joverflow"
-          version="0.0.0"/>
+@@ -69,6 +69,10 @@
  
+    <includes
+          id="org.openjdk.jmc.feature.joverflow"
++	   version="0.0.0"/>
++
 +   <includes
 +         id="org.openjdk.jmc.feature.console.ext.agent"
-+         version="0.0.0"/>
-+
+          version="0.0.0"/>
+ 
     <requires>
-       <import feature="org.eclipse.rcp" version="3.8.0" match="greaterOrEqual"/>
-       <import feature="org.eclipse.help" version="1.4.0" match="greaterOrEqual"/>
 diff --git a/application/pom.xml b/application/pom.xml
-index a2d52be..08462cc 100644
+index a2d52be..4d0015e 100644
 --- a/application/pom.xml
 +++ b/application/pom.xml
 @@ -82,6 +82,7 @@
  		<module>org.openjdk.jmc.feature.rcp</module>
  		<module>org.openjdk.jmc.feature.rcp.update</module>
  		<module>org.openjdk.jmc.feature.twitter</module>
-+	        <module>org.openjdk.jmc.feature.console.ext.agent</module>
++		<module>org.openjdk.jmc.feature.console.ext.agent</module>
  		<module>org.openjdk.jmc.flightrecorder.configuration</module>
  		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui</module>
  		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration</module>
@@ -92,27 +92,23 @@ index a2d52be..08462cc 100644
  		<module>tests</module>
  		<module>coverage</module>
 diff --git a/configuration/spotbugs/spotbugs-exclude.xml b/configuration/spotbugs/spotbugs-exclude.xml
-index 97a251c..87c2e2b 100644
+index 97a251c..bc50f52 100644
 --- a/configuration/spotbugs/spotbugs-exclude.xml
 +++ b/configuration/spotbugs/spotbugs-exclude.xml
-@@ -32,6 +32,102 @@
+@@ -32,6 +32,109 @@
     WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  -->
  <FindBugsFilter>
-+    <!-- copied from jmc-agent-plugin -->
-+    <Match>
++	<!-- copied from jmc-agent-plugin -->
++	<Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.AgentJmxHelper"/>
 +		<Method name="retrieveCurrentTransforms"/>
 +		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorBak"/>
 +		<Method name="doAddPages"/>
 +		<Bug pattern="REC_CATCH_EXCEPTION"/>
-+	</Match>
-+	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor"/>
-+		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
 +	<Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi"/>
@@ -124,12 +120,12 @@ index 97a251c..87c2e2b 100644
 +		<Bug pattern="UWF_UNWRITTEN_FIELD"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDocumentProvider"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.XmlDocumentProvider"/>
 +		<Method name="doSaveDocument"/>
 +		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDocumentProvider"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.XmlDocumentProvider"/>
 +		<Method name="doSaveDocument"/>
 +		<Bug pattern="DM_DEFAULT_ENCODING"/>
 +	</Match>
@@ -155,17 +151,32 @@ index 97a251c..87c2e2b 100644
 +		<Bug pattern="UUF_UNUSED_FIELD"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.NonRuleBasedDamagerRepairer"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage" />
++		<Method name="openFileDialog"/>
++		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
++	</Match>
++	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
++		<Method name="createSingleton"/>
++		<Bug pattern="DC_DOUBLECHECK" />
++	</Match>
++	<!-- This is a false positive. Eclipse handles initialization of critical components elsewhere -->
++    	<Match>
++    		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditor" />
++    		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
++   	</Match>
++    	<Match>
++		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.NonRuleBasedDamagerRepairer"/>
 +		<Method name="endOfLineOf"/>
 +		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.NonRuleBasedDamagerRepairer"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.NonRuleBasedDamagerRepairer"/>
 +		<Method name="getDamageRegion"/>
 +		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.tabs.editor.internal.XmlDoubleClickStrategy"/>
++		<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.XmlDoubleClickStrategy"/>
 +		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
 +	<Match>
@@ -174,31 +185,27 @@ index 97a251c..87c2e2b 100644
 +		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
 +	<Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.wizards.BaseWizardPage" />
-+		<Method name="openFileDialog"/>
-+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
++		<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorBak"/>
++		<Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
 +	</Match>
++    <!-- There is a blanket exclude on these types of bugs in JMC.
++     in UI classes the memory overhead is minimal and reworking it isn't really worth it -->
 +    <Match>
-+		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
-+		<Method name="createSingleton"/>
-+		<Bug pattern="DC_DOUBLECHECK" />
++    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventDetailSection" />
++    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
 +    </Match>
-+    <!-- Ignore file creation return value. If the file already exists we wouldn't have made this call. -->
 +    <Match>
-+    	<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.XmlDocumentProvider" />
-+    	<Method name="doSaveDocument" />
-+    	<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
++    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.EventListSection" />
++    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
 +    </Match>
-+    <!-- This is being caused by a switch on an enum -->
 +    <Match>
-+    	<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi" />
-+    	<Method name="bindAgentEditorActions" />
-+    	<Bug pattern="VO_VOLATILE_REFERENCE_TO_ARRAY" />
++    	<Class name="org.openjdk.jmc.console.ext.agent.editor.sections.GlobalConfigSection" />
++    	<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
 +    </Match>
      <!-- Skip I18n -->
      <Match>
          <Bug pattern="DM_DEFAULT_ENCODING"/>
-@@ -1138,4 +1234,4 @@
+@@ -1138,4 +1241,4 @@
  		<Class name="org.openjdk.jmc.rjmx.subscription.internal.EvilMethodsClass"/>
  	</Match>
  		

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -92,10 +92,10 @@ index a2d52be..08462cc 100644
  		<module>tests</module>
  		<module>coverage</module>
 diff --git a/configuration/spotbugs/spotbugs-exclude.xml b/configuration/spotbugs/spotbugs-exclude.xml
-index 97a251c..262e81c 100644
+index 97a251c..87c2e2b 100644
 --- a/configuration/spotbugs/spotbugs-exclude.xml
 +++ b/configuration/spotbugs/spotbugs-exclude.xml
-@@ -32,6 +32,90 @@
+@@ -32,6 +32,102 @@
     WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  -->
  <FindBugsFilter>
@@ -178,15 +178,27 @@ index 97a251c..262e81c 100644
 +		<Method name="openFileDialog"/>
 +		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
 +	</Match>
-+        <Match>
++    <Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
 +		<Method name="createSingleton"/>
 +		<Bug pattern="DC_DOUBLECHECK" />
-+        </Match>
++    </Match>
++    <!-- Ignore file creation return value. If the file already exists we wouldn't have made this call. -->
++    <Match>
++    	<Class name="org.openjdk.jmc.console.ext.agent.raweditor.internal.XmlDocumentProvider" />
++    	<Method name="doSaveDocument" />
++    	<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
++    </Match>
++    <!-- This is being caused by a switch on an enum -->
++    <Match>
++    	<Class name="org.openjdk.jmc.console.ext.agent.editor.AgentEditorUi" />
++    	<Method name="bindAgentEditorActions" />
++    	<Bug pattern="VO_VOLATILE_REFERENCE_TO_ARRAY" />
++    </Match>
      <!-- Skip I18n -->
      <Match>
          <Bug pattern="DM_DEFAULT_ENCODING"/>
-@@ -1138,4 +1222,4 @@
+@@ -1138,4 +1234,4 @@
  		<Class name="org.openjdk.jmc.rjmx.subscription.internal.EvilMethodsClass"/>
  	</Match>
  		

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/application/org.openjdk.jmc.console.ext.agent/pom.xml b/application/org.openjdk.jmc.console.ext.agent/pom.xml
-index 4f39161a..8d4f7d8a 100644
+index f4f39ff..c9579d2 100644
 --- a/application/org.openjdk.jmc.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.console.ext.agent/pom.xml
 @@ -39,9 +39,7 @@
@@ -10,7 +10,7 @@ index 4f39161a..8d4f7d8a 100644
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
 +		<artifactId>missioncontrol.application</artifactId>
- 		<version>8.0.0-SNAPSHOT</version>
+ 		<version>8.1.0-SNAPSHOT</version>
  	</parent>
  
 @@ -53,12 +51,7 @@
@@ -28,7 +28,7 @@ index 4f39161a..8d4f7d8a 100644
  
  	<build>
 diff --git a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
-index bb080eb8..1a74fd51 100644
+index 4f9ae6e..4f72504 100644
 --- a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 @@ -37,9 +37,7 @@
@@ -39,7 +39,7 @@ index bb080eb8..1a74fd51 100644
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
 +		<artifactId>missioncontrol.application</artifactId>
- 		<version>8.0.0-SNAPSHOT</version>
+ 		<version>8.1.0-SNAPSHOT</version>
  	</parent>
  	
 @@ -48,8 +46,6 @@
@@ -53,7 +53,7 @@ index bb080eb8..1a74fd51 100644
  	</properties>
  </project>
 diff --git a/application/org.openjdk.jmc.feature.rcp/feature.xml b/application/org.openjdk.jmc.feature.rcp/feature.xml
-index af0c2f2f..a7af3c8a 100644
+index ee1992f..bf35ec4 100644
 --- a/application/org.openjdk.jmc.feature.rcp/feature.xml
 +++ b/application/org.openjdk.jmc.feature.rcp/feature.xml
 @@ -71,6 +71,10 @@
@@ -68,31 +68,27 @@ index af0c2f2f..a7af3c8a 100644
        <import feature="org.eclipse.rcp" version="3.8.0" match="greaterOrEqual"/>
        <import feature="org.eclipse.help" version="1.4.0" match="greaterOrEqual"/>
 diff --git a/application/pom.xml b/application/pom.xml
-index bccc1036..0d89116b 100644
+index a2d52be..08462cc 100644
 --- a/application/pom.xml
 +++ b/application/pom.xml
-@@ -81,7 +81,8 @@
- 		<module>org.openjdk.jmc.feature.pde</module>
+@@ -82,6 +82,7 @@
  		<module>org.openjdk.jmc.feature.rcp</module>
  		<module>org.openjdk.jmc.feature.rcp.update</module>
--		<module>org.openjdk.jmc.feature.twitter</module>
-+        <module>org.openjdk.jmc.feature.twitter</module>
-+        <module>org.openjdk.jmc.feature.console.ext.agent</module>
+ 		<module>org.openjdk.jmc.feature.twitter</module>
++	        <module>org.openjdk.jmc.feature.console.ext.agent</module>
  		<module>org.openjdk.jmc.flightrecorder.configuration</module>
  		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui</module>
  		<module>org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration</module>
-@@ -113,7 +114,8 @@
- 		<module>org.openjdk.jmc.ui</module>
+@@ -114,6 +115,7 @@
  		<module>org.openjdk.jmc.ui.common</module>
  		<module>org.openjdk.jmc.updatesite.ide</module>
--		<module>org.openjdk.jmc.updatesite.rcp</module>
-+        <module>org.openjdk.jmc.updatesite.rcp</module>
-+        <module>org.openjdk.jmc.console.ext.agent</module>
+ 		<module>org.openjdk.jmc.updatesite.rcp</module>
++		<module>org.openjdk.jmc.console.ext.agent</module>
  		<module>l10n</module>
  		<module>tests</module>
  		<module>coverage</module>
 diff --git a/configuration/spotbugs/spotbugs-exclude.xml b/configuration/spotbugs/spotbugs-exclude.xml
-index 97a251c4..be74fbca 100644
+index 97a251c..262e81c 100644
 --- a/configuration/spotbugs/spotbugs-exclude.xml
 +++ b/configuration/spotbugs/spotbugs-exclude.xml
 @@ -32,6 +32,90 @@
@@ -178,11 +174,18 @@ index 97a251c4..be74fbca 100644
 +		<Method name="openFileDialog"/>
 +		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
 +	</Match>
-+	<Match>
++        <Match>
 +		<Class name="org.openjdk.jmc.console.ext.agent.manager.model.PresetRepositoryFactory" />
 +		<Method name="createSingleton"/>
 +		<Bug pattern="DC_DOUBLECHECK" />
-+	</Match>
++        </Match>
      <!-- Skip I18n -->
      <Match>
          <Bug pattern="DM_DEFAULT_ENCODING"/>
+@@ -1138,4 +1222,4 @@
+ 		<Class name="org.openjdk.jmc.rjmx.subscription.internal.EvilMethodsClass"/>
+ 	</Match>
+ 		
+-</FindBugsFilter>
+\ No newline at end of file
++</FindBugsFilter>

--- a/scripts/diff.patch
+++ b/scripts/diff.patch
@@ -1,18 +1,20 @@
 diff --git a/application/org.openjdk.jmc.console.ext.agent/pom.xml b/application/org.openjdk.jmc.console.ext.agent/pom.xml
-index f4f39ff..c9579d2 100644
+index f4f39ff..d2b5d24 100644
 --- a/application/org.openjdk.jmc.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.console.ext.agent/pom.xml
-@@ -39,9 +39,7 @@
+@@ -39,10 +39,8 @@
  
  	<parent>
  		<groupId>org.openjdk.jmc</groupId>
 -		<!--artifactId>missioncontrol.application</artifactId-->
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
+-		<version>8.1.0-SNAPSHOT</version>
 +		<artifactId>missioncontrol.application</artifactId>
- 		<version>8.1.0-SNAPSHOT</version>
++		<version>${revision}${changelist}</version>
  	</parent>
  
+ 	<artifactId>org.openjdk.jmc.console.ext.agent</artifactId>
 @@ -53,12 +51,7 @@
  		<jmc.agent.version>1.0.0-SNAPSHOT</jmc.agent.version>
  		<java.version>1.8</java.version>
@@ -28,20 +30,22 @@ index f4f39ff..c9579d2 100644
  
  	<build>
 diff --git a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
-index 4f9ae6e..4f72504 100644
+index 4f9ae6e..b13eb10 100644
 --- a/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
 +++ b/application/org.openjdk.jmc.feature.console.ext.agent/pom.xml
-@@ -37,9 +37,7 @@
+@@ -37,10 +37,8 @@
  
  	<parent>
  		<groupId>org.openjdk.jmc</groupId>
 -		<!--artifactId>missioncontrol.application</artifactId-->
 -		<!--TODO: replace this with above when merging to JMC repo-->
 -		<artifactId>missioncontrol.application.jmc-agent-plugin</artifactId>
+-		<version>8.1.0-SNAPSHOT</version>
 +		<artifactId>missioncontrol.application</artifactId>
- 		<version>8.1.0-SNAPSHOT</version>
++		<version>${revision}${changelist}</version>
  	</parent>
  	
+ 	<artifactId>org.openjdk.jmc.feature.console.ext.agent</artifactId>
 @@ -48,8 +46,6 @@
  	<packaging>eclipse-feature</packaging>
  	


### PR DESCRIPTION
This PR updates the copyright years in the headers to the current year as pointed out by Marcus in the review for the upstream agent plugin PR